### PR TITLE
Implemented compare products view with slider feature

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["react-app"]
+  "presets": ["react-app"],
+  "plugins": ["react-hot-loader/babel"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5390,6 +5390,12 @@
         }
       }
     },
+    "dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
+      "dev": true
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -7275,6 +7281,16 @@
       "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
+      }
+    },
+    "global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dev": true,
+      "requires": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
       }
     },
     "global-dirs": {
@@ -10984,6 +11000,15 @@
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true
     },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "dev": true,
+      "requires": {
+        "dom-walk": "^0.1.0"
+      }
+    },
     "mini-create-react-context": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz",
@@ -13095,10 +13120,40 @@
         "scheduler": "^0.19.1"
       }
     },
+    "react-hot-loader": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.13.0.tgz",
+      "integrity": "sha512-JrLlvUPqh6wIkrK2hZDfOyq/Uh/WeVEr8nc7hkn2/3Ul0sx1Kr5y4kOGNacNRoj7RhwLNcQ3Udf1KJXrqc0ZtA==",
+      "dev": true,
+      "requires": {
+        "fast-levenshtein": "^2.0.6",
+        "global": "^4.3.0",
+        "hoist-non-react-statics": "^3.3.0",
+        "loader-utils": "^1.1.0",
+        "prop-types": "^15.6.1",
+        "react-lifecycles-compat": "^3.0.4",
+        "shallowequal": "^1.1.0",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        }
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "dev": true
     },
     "react-paginate": {
       "version": "7.0.0",
@@ -14566,6 +14621,12 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "prettier-loader": "^3.3.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-hot-loader": "^4.13.0",
     "react-router-dom": "^5.2.0",
     "sass-loader": "^9.0.3",
     "ts-jest": "^26.5.1",

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -1,0 +1,19 @@
+import { hot } from 'react-hot-loader';
+import React, { StrictMode } from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import Header from './components/views/header';
+import Main from './components/views/main';
+import Footer from './components/views/footer';
+
+const App = () => (
+  <StrictMode>
+    <Router>
+      <Header />
+      <Main />
+      <Footer />
+    </Router>
+  </StrictMode>
+);
+
+// eslint-disable-next-line
+export default hot(module)(App);

--- a/src/frontend/assets/styles/main.scss
+++ b/src/frontend/assets/styles/main.scss
@@ -4,6 +4,13 @@
 @import 'views/cart';
 @import 'views/pagination';
 @import 'views/compareProducts';
+@import 'views/scroller';
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
 
 html {
   font-size: 16px;

--- a/src/frontend/assets/styles/main.scss
+++ b/src/frontend/assets/styles/main.scss
@@ -3,6 +3,7 @@
 @import 'views/productList';
 @import 'views/cart';
 @import 'views/pagination';
+@import 'views/compareProducts';
 
 .app-root {
   display: grid;

--- a/src/frontend/assets/styles/main.scss
+++ b/src/frontend/assets/styles/main.scss
@@ -5,6 +5,10 @@
 @import 'views/pagination';
 @import 'views/compareProducts';
 
+html {
+  font-size: 16px;
+}
+
 .app-root {
   display: grid;
   grid-template-columns: 3fr 1fr;

--- a/src/frontend/assets/styles/views/compareProducts.scss
+++ b/src/frontend/assets/styles/views/compareProducts.scss
@@ -1,6 +1,10 @@
+.compare-products-candidates,
+.compare-products {
+  --product-list-item-width: 200px;
+}
+
 .compare-products-candidates {
   display: flex;
-  width: fit-content;
   border: 1px solid orange;
   margin: 1rem;
 
@@ -19,6 +23,7 @@
     justify-content: space-between;
     margin: 0 0.5rem;
     height: 3rem;
+    width: var(--product-list-item-width);
   }
 
   &__actions {
@@ -55,7 +60,7 @@
 
   &__row {
     display: grid;
-    grid-template-columns: repeat(var(--compare-columns-number, auto), minmax(200px,1fr));
+    grid-template-columns: repeat(var(--compare-columns-number, auto), minmax(var(--product-list-item-width),1fr));
   }
 
   &__cell {
@@ -76,5 +81,11 @@
 
   &__item-short-description {
     padding-left: 1.5rem;
+  }
+}
+
+@media screen and (min-width: 1366px) {
+  .compare-products-candidates {
+    max-width: 75%;
   }
 }

--- a/src/frontend/assets/styles/views/compareProducts.scss
+++ b/src/frontend/assets/styles/views/compareProducts.scss
@@ -36,19 +36,18 @@
   align-items: center;
   justify-content: space-between;
 
+  &--slider-control-row {
+    margin-bottom: 1rem;
+  }
+
   &__table {
-    //display: grid;
-    //grid-template-columns: 1fr 2fr;
     display: flex;
     width: 100%;
     height: 90%;
   }
 
   &__head, &__body {
-    //display: grid;
-    //grid-template-rows: repeat(var(--compare-rows-number, auto), auto);
     height: 100%;
-
     display: flex;
     flex-direction: column;
     justify-content: space-between;
@@ -60,7 +59,7 @@
   }
 
   &__cell {
-    //height: 100%;
+
   }
 }
 

--- a/src/frontend/assets/styles/views/compareProducts.scss
+++ b/src/frontend/assets/styles/views/compareProducts.scss
@@ -3,39 +3,52 @@
   width: fit-content;
   border: 1px solid orange;
   margin: 1rem;
+
+  &__list {
+    list-style: none;
+    display: inline-flex;
+    justify-content: space-around;
+    margin: 1rem 0 1rem 1rem;
+    padding: 0 1rem 0 0;
+    border-right: 1px dashed orange;
+  }
+
+  &__list-item {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    margin: 0 0.5rem;
+    height: 3rem;
+  }
+
+  &__actions {
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: space-between;
+    margin: 1rem;
+    min-height: 3rem;
+  }
 }
 
-.compare-products-candidates__list {
-  list-style: none;
-  display: inline-flex;
-  justify-content: space-around;
-  margin: 1rem 0 1rem 1rem;
-  padding: 0 1rem 0 0;
-  border-right: 1px dashed orange;
-}
-
-.compare-products-candidates__actions {
-  display: inline-flex;
-  flex-direction: column;
-  justify-content: space-between;
-  margin: 1rem;
-  min-height: 3rem;
-}
-
-.compare-products-candidates__list-item {
+.compare-products {
+  height: 100%;
   display: flex;
-  flex-direction: column;
+  align-items: center;
   justify-content: space-between;
-  margin: 0 0.5rem;
-  height: 3rem;
 }
 
 .compare-products-list {
   display: flex;
   list-style: none;
-}
+  margin: 0 24px;
 
-.compare-products-list__item {
-  margin: 0 0.5rem;
-  border: 1px solid orange;
+  &__item {
+    margin: 0 0.5rem;
+    border: 1px solid orange;
+    min-width: 225px;
+  }
+
+  &__item-short-description {
+    padding-left: 1.5rem;
+  }
 }

--- a/src/frontend/assets/styles/views/compareProducts.scss
+++ b/src/frontend/assets/styles/views/compareProducts.scss
@@ -35,6 +35,29 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+
+  &__table {
+    //display: grid;
+    //grid-template-columns: 1fr 2fr;
+    display: flex;
+    width: 100%;
+    height: 90%;
+  }
+
+  &__head, &__body {
+    display: grid;
+    grid-template-rows: repeat(var(--compare-rows-number, auto), auto);
+    height: 100%;
+  }
+
+  &__row {
+    display: grid;
+    grid-template-columns: repeat(var(--compare-columns-number, auto), minmax(200px,1fr));
+  }
+
+  &__cell {
+    //height: 100%;
+  }
 }
 
 .compare-products-list {

--- a/src/frontend/assets/styles/views/compareProducts.scss
+++ b/src/frontend/assets/styles/views/compareProducts.scss
@@ -45,9 +45,13 @@
   }
 
   &__head, &__body {
-    display: grid;
-    grid-template-rows: repeat(var(--compare-rows-number, auto), auto);
+    //display: grid;
+    //grid-template-rows: repeat(var(--compare-rows-number, auto), auto);
     height: 100%;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
   }
 
   &__row {

--- a/src/frontend/assets/styles/views/compareProducts.scss
+++ b/src/frontend/assets/styles/views/compareProducts.scss
@@ -1,0 +1,17 @@
+.compare-products {
+  width: fit-content;
+  border: 1px solid orange;
+}
+
+.compare-products__list {
+  list-style: none;
+  display: inline-flex;
+  justify-content: space-around;
+  padding: 0;
+}
+
+.compare-products__list-item {
+  display: flex;
+  flex-direction: column;
+  margin: 0 10px;
+}

--- a/src/frontend/assets/styles/views/compareProducts.scss
+++ b/src/frontend/assets/styles/views/compareProducts.scss
@@ -1,19 +1,33 @@
 .compare-products-candidates {
+  display: flex;
   width: fit-content;
   border: 1px solid orange;
+  margin: 1rem;
 }
 
 .compare-products-candidates__list {
   list-style: none;
   display: inline-flex;
   justify-content: space-around;
-  padding: 0;
+  margin: 1rem 0 1rem 1rem;
+  padding: 0 1rem 0 0;
+  border-right: 1px dashed orange;
+}
+
+.compare-products-candidates__actions {
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: space-between;
+  margin: 1rem;
+  min-height: 3rem;
 }
 
 .compare-products-candidates__list-item {
   display: flex;
   flex-direction: column;
-  margin: 0 10px;
+  justify-content: space-between;
+  margin: 0 0.5rem;
+  height: 3rem;
 }
 
 .compare-products-list {
@@ -22,6 +36,6 @@
 }
 
 .compare-products-list__item {
-  margin: 0 10px;
+  margin: 0 0.5rem;
   border: 1px solid orange;
 }

--- a/src/frontend/assets/styles/views/compareProducts.scss
+++ b/src/frontend/assets/styles/views/compareProducts.scss
@@ -1,17 +1,27 @@
-.compare-products {
+.compare-products-candidates {
   width: fit-content;
   border: 1px solid orange;
 }
 
-.compare-products__list {
+.compare-products-candidates__list {
   list-style: none;
   display: inline-flex;
   justify-content: space-around;
   padding: 0;
 }
 
-.compare-products__list-item {
+.compare-products-candidates__list-item {
   display: flex;
   flex-direction: column;
   margin: 0 10px;
+}
+
+.compare-products-list {
+  display: flex;
+  list-style: none;
+}
+
+.compare-products-list__item {
+  margin: 0 10px;
+  border: 1px solid orange;
 }

--- a/src/frontend/assets/styles/views/productList.scss
+++ b/src/frontend/assets/styles/views/productList.scss
@@ -24,4 +24,8 @@
       word-break: break-word;
     }
   }
+
+  &__toggle-comparable {
+    display: block;
+  }
 }

--- a/src/frontend/assets/styles/views/scroller.scss
+++ b/src/frontend/assets/styles/views/scroller.scss
@@ -1,8 +1,10 @@
-.scrollable {
+.scrollable-parent {
   overflow: hidden;
   width: 100%;
   height: 100%;
   position: relative;
+
+  margin-left: 100px;
 
   [data-scrollable] {
     position: absolute;
@@ -25,7 +27,7 @@
   border-radius: 50px;
   color: orange;
 
-  &:hover {
+  &:not([disabled]):hover {
     cursor: pointer;
   }
 

--- a/src/frontend/assets/styles/views/scroller.scss
+++ b/src/frontend/assets/styles/views/scroller.scss
@@ -8,6 +8,7 @@
     position: absolute;
     top: 0;
     left: 0;
+    margin: 0; // remove margin to correctly calculate offset to parent
 
     transform: translateX(calc(var(--scrollValue, 0) * 1px));
     transition: transform 0.25s;

--- a/src/frontend/assets/styles/views/scroller.scss
+++ b/src/frontend/assets/styles/views/scroller.scss
@@ -1,0 +1,11 @@
+.scroller-btn {
+  width: 50px;
+  height: 50px;
+  background: blue;
+  border-radius: 50px;
+  display: none;
+}
+
+.scroller-btn--visible {
+  display: block;
+}

--- a/src/frontend/assets/styles/views/scroller.scss
+++ b/src/frontend/assets/styles/views/scroller.scss
@@ -10,8 +10,10 @@
   left: 0;
   margin: 0; // remove margin to correctly calculate offset to parent
 
-  transition: transform 0.25s;
-  transform: translateX(calc(var(--scrollValue, 0) * 1px));
+  &:not(.initial-render) {
+    transition: transform 0.25s;
+    transform: translateX(calc(var(--scrollValue, 0) * 1px));
+  }
 }
 
 .scroller-btn {

--- a/src/frontend/assets/styles/views/scroller.scss
+++ b/src/frontend/assets/styles/views/scroller.scss
@@ -1,20 +1,20 @@
 .scrollable-parent {
   overflow: hidden;
   width: 100%;
-  height: 100%;
+  //height: 100%;
   position: relative;
 
-  margin-left: 100px;
+  //margin-left: 100px;
+}
 
-  [data-scrollable] {
-    position: absolute;
-    top: 0;
-    left: 0;
-    margin: 0; // remove margin to correctly calculate offset to parent
+[data-scrollable] {
+  position: absolute;
+  top: 0;
+  left: 0;
+  margin: 0; // remove margin to correctly calculate offset to parent
 
-    transform: translateX(calc(var(--scrollValue, 0) * 1px));
-    transition: transform 0.25s;
-  }
+  transition: transform 0.25s;
+  transform: translateX(calc(var(--scrollValue, 0) * 1px));
 }
 
 .scroller-btn {

--- a/src/frontend/assets/styles/views/scroller.scss
+++ b/src/frontend/assets/styles/views/scroller.scss
@@ -1,10 +1,7 @@
-.scrollable-parent {
+[data-scrollable-parent] {
   overflow: hidden;
   width: 100%;
-  //height: 100%;
   position: relative;
-
-  //margin-left: 100px;
 }
 
 [data-scrollable] {

--- a/src/frontend/assets/styles/views/scroller.scss
+++ b/src/frontend/assets/styles/views/scroller.scss
@@ -1,11 +1,34 @@
+.scrollable {
+  overflow: hidden;
+  width: 100%;
+  height: 100%;
+  position: relative;
+
+  [data-scrollable] {
+    position: absolute;
+    top: 0;
+    left: 0;
+
+    transform: translateX(calc(var(--scrollValue, 0) * 1px));
+    transition: transform 0.25s;
+  }
+}
+
 .scroller-btn {
+  display: none;
+  position: relative;
+  z-index: 1;
   width: 50px;
   height: 50px;
   background: blue;
   border-radius: 50px;
-  display: none;
-}
+  color: orange;
 
-.scroller-btn--visible {
-  display: block;
+  &:hover {
+    cursor: pointer;
+  }
+
+  &--visible {
+    display: block;
+  }
 }

--- a/src/frontend/components/pages/compare.js
+++ b/src/frontend/components/pages/compare.js
@@ -11,37 +11,42 @@ export default function Compare() {
 
   useEffect(() => {
     tableRef.current.style.setProperty('--compare-rows-number', productDetailsHeadersKeys.length);
+    tableRef.current.style.setProperty('--compare-columns-number', Object.keys(comparableProductsData).length);
   }, []);
 
   return (
     <section className="compare-products">
-      <Scroller
-        forwardProps={{ productDetailsHeadersKeys, tableRef }}
-        render={(elementRef, { tableRef }) => {
-          // console.warn('[render] elementRef:', elementRef, ' /curr:', elementRef.current);
+      <div ref={tableRef} className="compare-products__table">
+        <div className="compare-products__head">
+          {productDetailsHeadersKeys.map((detailHeader, index) => (
+            <div className="compare-products__cell" key={`header-row-${index}`}>
+              {productDetailsHeaders[detailHeader]}
+            </div>
+          ))}
+        </div>
+        <Scroller
+          forwardProps={{ productDetailsHeadersKeys }}
+          render={({ elementRef, resizedObservedRef }) => {
+            // console.warn('[render] elementRef:', elementRef, ' /curr:', elementRef.current);
 
-          return (
-            <table ref={tableRef} className="compare-products__table scrollable-parent">
-              <thead>
-                {productDetailsHeadersKeys.map((detailHeader, index) => (
-                  <tr key={`header-row-${index}`}>
-                    <th>{productDetailsHeaders[detailHeader]}</th>
-                  </tr>
-                ))}
-              </thead>
-              <tbody ref={elementRef}>
-                {productDetailsHeadersKeys.map((detailHeader, index) => (
-                  <tr key={`body-row-${index}`}>
-                    {comparableProductsData.map((productData, i) => (
-                      <td key={`cell-${i}`}>{prepareSpecificProductDetail(detailHeader, productData[detailHeader])}</td>
-                    ))}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          );
-        }}
-      />
+            return (
+              <div className="scrollable-parent">
+                <div className="compare-products__body" ref={elementRef}>
+                  {productDetailsHeadersKeys.map((detailHeader, headerIndex) => (
+                    <div className="compare-products__row" ref={resizedObservedRef} key={`body-row-${headerIndex}`}>
+                      {comparableProductsData.map((productData, dataIndex) => (
+                        <div className="compare-products__cell" key={`cell-${dataIndex}`}>
+                          {prepareSpecificProductDetail(detailHeader, productData[detailHeader])}
+                        </div>
+                      ))}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          }}
+        />
+      </div>
     </section>
   );
 }

--- a/src/frontend/components/pages/compare.js
+++ b/src/frontend/components/pages/compare.js
@@ -1,17 +1,24 @@
 import React from 'react';
 import appStore from '../../features/appStore';
 import ProductDetails from '../views/productDetails';
+import Scroller from '../utils/scroller';
 
 export default function Compare() {
   return (
-    <ol className="compare-products-list">
-      {appStore.productComparisonState.map((product) => {
-        return (
-          <li key={product._id} className="compare-products-list__item">
-            <ProductDetails product={product} />
-          </li>
-        );
-      })}
-    </ol>
+    <section className="compare-products">
+      <Scroller
+        render={(listRef) => (
+          <ol ref={listRef} className="compare-products-list">
+            {appStore.productComparisonState.map((product) => {
+              return (
+                <li key={product._id} className="compare-products-list__item">
+                  <ProductDetails product={product} />
+                </li>
+              );
+            })}
+          </ol>
+        )}
+      />
+    </section>
   );
 }

--- a/src/frontend/components/pages/compare.js
+++ b/src/frontend/components/pages/compare.js
@@ -17,32 +17,39 @@ export default function Compare() {
   return (
     <section className="compare-products">
       <div ref={tableRef} className="compare-products__table">
-        <div className="compare-products__head">
-          {productDetailsHeadersKeys.map((detailHeader, index) => (
-            <div className="compare-products__cell" key={`header-row-${index}`}>
-              {productDetailsHeaders[detailHeader]}
-            </div>
-          ))}
-        </div>
         <Scroller
           forwardProps={{ productDetailsHeadersKeys }}
-          render={({ elementRef, resizedObservedRef }) => {
+          render={({ elementRef, resizedObservedHeadRef, resizedObservedBodyRef }) => {
             // console.warn('[render] elementRef:', elementRef, ' /curr:', elementRef.current);
 
             return (
-              <div className="scrollable-parent">
-                <div className="compare-products__body" ref={elementRef}>
-                  {productDetailsHeadersKeys.map((detailHeader, headerIndex) => (
-                    <div className="compare-products__row" ref={resizedObservedRef} key={`body-row-${headerIndex}`}>
-                      {comparableProductsData.map((productData, dataIndex) => (
-                        <div className="compare-products__cell" key={`cell-${dataIndex}`}>
-                          {prepareSpecificProductDetail(detailHeader, productData[detailHeader])}
-                        </div>
-                      ))}
+              <>
+                <div className="compare-products__head">
+                  {productDetailsHeadersKeys.map((detailHeader, index) => (
+                    <div className="compare-products__cell" ref={resizedObservedHeadRef} key={`header-row-${index}`}>
+                      {productDetailsHeaders[detailHeader]}
                     </div>
                   ))}
                 </div>
-              </div>
+
+                <div className="scrollable-parent">
+                  <div className="compare-products__body" ref={elementRef}>
+                    {productDetailsHeadersKeys.map((detailHeader, headerIndex) => (
+                      <div
+                        className="compare-products__row"
+                        ref={resizedObservedBodyRef}
+                        key={`body-row-${headerIndex}`}
+                      >
+                        {comparableProductsData.map((productData, dataIndex) => (
+                          <div className="compare-products__cell" key={`cell-${dataIndex}`}>
+                            {prepareSpecificProductDetail(detailHeader, productData[detailHeader])}
+                          </div>
+                        ))}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </>
             );
           }}
         />

--- a/src/frontend/components/pages/compare.js
+++ b/src/frontend/components/pages/compare.js
@@ -1,7 +1,9 @@
+import { toJS } from 'mobx';
 import React, { useRef, createRef, useEffect, useCallback } from 'react';
 import appStore from '../../features/appStore';
 import { getProductDetailsData, prepareSpecificProductDetail, getProductDetailsHeaders } from '../views/productDetails';
 import Scroller from '../utils/scroller';
+import { ProductItemLink } from '../views/productItem';
 
 const translations = {
   productsAmount: 'produktów',
@@ -58,6 +60,12 @@ export default function Compare() {
           {comparableProductsData.map((productData, dataIndex) => (
             <div className="compare-products__cell" role="cell" key={`cell-${dataIndex}`}>
               {prepareSpecificProductDetail(detailHeader, productData[detailHeader])}
+
+              {detailHeader === 'name' && (
+                <ProductItemLink
+                  productData={toJS(appStore.productComparisonState[dataIndex], { recurseEverything: true })}
+                />
+              )}
             </div>
           ))}
         </div>

--- a/src/frontend/components/pages/compare.js
+++ b/src/frontend/components/pages/compare.js
@@ -78,20 +78,27 @@ export default function Compare() {
     <section className="compare-products">
       <div ref={tableRef} className="compare-products__table" role="table">
         <Scroller
-          forwardProps={{ productDetailsHeadersKeys }}
-          render={({ elementRef, headRowRefGetter, bodyRowRefGetter }) => (
-            <>
-              <div className="compare-products__head" role="rowgroup">
-                {productDetailsHeadersKeys.map(getTableHeadContent(headRowRefGetter))}
-              </div>
+          render={({ elementRef, multipleRefsGetter }) => {
+            const { createRefGetter, REF_TYPE } = multipleRefsGetter;
+            const [headRowRefGetter, bodyRowRefGetter] = [
+              createRefGetter(REF_TYPE.HEAD),
+              createRefGetter(REF_TYPE.BODY),
+            ];
 
-              <div>
-                <div className="compare-products__body" ref={elementRef} role="rowgroup">
-                  {productDetailsHeadersKeys.map(getTableBodyContent(bodyRowRefGetter))}
+            return (
+              <>
+                <div className="compare-products__head" role="rowgroup">
+                  {productDetailsHeadersKeys.map(getTableHeadContent(headRowRefGetter))}
                 </div>
-              </div>
-            </>
-          )}
+
+                <div>
+                  <div className="compare-products__body" ref={elementRef} role="rowgroup">
+                    {productDetailsHeadersKeys.map(getTableBodyContent(bodyRowRefGetter))}
+                  </div>
+                </div>
+              </>
+            );
+          }}
         />
       </div>
     </section>

--- a/src/frontend/components/pages/compare.js
+++ b/src/frontend/components/pages/compare.js
@@ -1,24 +1,36 @@
 import React from 'react';
 import appStore from '../../features/appStore';
-import ProductDetails from '../views/productDetails';
-import Scroller from '../utils/scroller';
+import { getProductDetailsData, prepareSpecificProductDetail, getProductDetailsHeaders } from '../views/productDetails';
+// import Scroller from '../utils/scroller';
 
 export default function Compare() {
+  const productDetailsHeaders = getProductDetailsHeaders();
+  const productDetailsHeadersKeys = Object.keys(productDetailsHeaders).filter((header) => header !== 'relatedProducts');
+  const comparableProductsData = appStore.productComparisonState.map((product) => getProductDetailsData(product));
+
   return (
     <section className="compare-products">
-      <Scroller
-        render={(listRef) => (
-          <ol ref={listRef} data-scrollable="true" className="compare-products-list">
-            {appStore.productComparisonState.map((product) => {
-              return (
-                <li key={product._id} className="compare-products-list__item">
-                  <ProductDetails product={product} />
-                </li>
-              );
-            })}
-          </ol>
-        )}
-      />
+      {/*<Scroller*/}
+      {/*  render={(listRef) => (*/}
+      {/*    <>*/}
+      <table>
+        <thead>
+          {productDetailsHeadersKeys.map((detailHeader, index) => (
+            <tr key={`header-row-${index}`}>
+              <th>{productDetailsHeaders[detailHeader]}</th>
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {productDetailsHeadersKeys.map((detailHeader, index) => (
+            <tr key={`body-row-${index}`}>
+              {comparableProductsData.map((productData, i) => (
+                <td key={`cell-${i}`}>{prepareSpecificProductDetail(detailHeader, productData[detailHeader])}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </section>
   );
 }

--- a/src/frontend/components/pages/compare.js
+++ b/src/frontend/components/pages/compare.js
@@ -1,36 +1,47 @@
-import React from 'react';
+import React, { useState, createRef, useEffect } from 'react';
 import appStore from '../../features/appStore';
 import { getProductDetailsData, prepareSpecificProductDetail, getProductDetailsHeaders } from '../views/productDetails';
-// import Scroller from '../utils/scroller';
+import Scroller from '../utils/scroller';
 
 export default function Compare() {
+  const [tableRef] = useState(createRef);
   const productDetailsHeaders = getProductDetailsHeaders();
   const productDetailsHeadersKeys = Object.keys(productDetailsHeaders).filter((header) => header !== 'relatedProducts');
   const comparableProductsData = appStore.productComparisonState.map((product) => getProductDetailsData(product));
 
+  useEffect(() => {
+    tableRef.current.style.setProperty('--compare-rows-number', productDetailsHeadersKeys.length);
+  }, []);
+
   return (
     <section className="compare-products">
-      {/*<Scroller*/}
-      {/*  render={(listRef) => (*/}
-      {/*    <>*/}
-      <table>
-        <thead>
-          {productDetailsHeadersKeys.map((detailHeader, index) => (
-            <tr key={`header-row-${index}`}>
-              <th>{productDetailsHeaders[detailHeader]}</th>
-            </tr>
-          ))}
-        </thead>
-        <tbody>
-          {productDetailsHeadersKeys.map((detailHeader, index) => (
-            <tr key={`body-row-${index}`}>
-              {comparableProductsData.map((productData, i) => (
-                <td key={`cell-${i}`}>{prepareSpecificProductDetail(detailHeader, productData[detailHeader])}</td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <Scroller
+        forwardProps={{ productDetailsHeadersKeys, tableRef }}
+        render={(elementRef, { tableRef }) => {
+          // console.warn('[render] elementRef:', elementRef, ' /curr:', elementRef.current);
+
+          return (
+            <table ref={tableRef} className="compare-products__table scrollable-parent">
+              <thead>
+                {productDetailsHeadersKeys.map((detailHeader, index) => (
+                  <tr key={`header-row-${index}`}>
+                    <th>{productDetailsHeaders[detailHeader]}</th>
+                  </tr>
+                ))}
+              </thead>
+              <tbody ref={elementRef}>
+                {productDetailsHeadersKeys.map((detailHeader, index) => (
+                  <tr key={`body-row-${index}`}>
+                    {comparableProductsData.map((productData, i) => (
+                      <td key={`cell-${i}`}>{prepareSpecificProductDetail(detailHeader, productData[detailHeader])}</td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          );
+        }}
+      />
     </section>
   );
 }

--- a/src/frontend/components/pages/compare.js
+++ b/src/frontend/components/pages/compare.js
@@ -1,59 +1,95 @@
-import React, { useState, createRef, useEffect } from 'react';
+import React, { useRef, createRef, useEffect, useCallback } from 'react';
 import appStore from '../../features/appStore';
 import { getProductDetailsData, prepareSpecificProductDetail, getProductDetailsHeaders } from '../views/productDetails';
 import Scroller from '../utils/scroller';
 
+const translations = {
+  productsAmount: 'produktów',
+};
+
 export default function Compare() {
-  const [tableRef] = useState(createRef);
-  const productDetailsHeaders = getProductDetailsHeaders();
-  const productDetailsHeadersKeys = Object.keys(productDetailsHeaders).filter((header) => header !== 'relatedProducts');
-  const comparableProductsData = appStore.productComparisonState.map((product) => getProductDetailsData(product));
+  const tableRef = useRef(createRef());
+  const {
+    nameHeaderIndex,
+    productDetailsHeaders,
+    productDetailsHeadersKeys,
+    comparableProductsData,
+  } = prepareComparisonData(getProductDetailsHeaders());
+
+  const setTableStylingCSSVariables = () => {
+    tableRef.current.style.setProperty('--compare-rows-number', productDetailsHeadersKeys.length);
+    tableRef.current.style.setProperty('--compare-columns-number', comparableProductsData.length);
+  };
+
+  const getClassForNameHeader = useCallback((index) => {
+    return nameHeaderIndex === index ? 'compare-products--slider-control-row' : '';
+  }, []);
+
+  const getProductsAmountText = useCallback(
+    () => `${comparableProductsData.length} ${translations.productsAmount}`,
+    []
+  );
 
   useEffect(() => {
-    tableRef.current.style.setProperty('--compare-rows-number', productDetailsHeadersKeys.length);
-    tableRef.current.style.setProperty('--compare-columns-number', Object.keys(comparableProductsData).length);
+    setTableStylingCSSVariables();
   }, []);
 
   return (
     <section className="compare-products">
-      <div ref={tableRef} className="compare-products__table">
+      <div ref={tableRef} className="compare-products__table" role="table">
         <Scroller
           forwardProps={{ productDetailsHeadersKeys }}
-          render={({ elementRef, resizedObservedHeadRef, resizedObservedBodyRef }) => {
-            // console.warn('[render] elementRef:', elementRef, ' /curr:', elementRef.current);
+          render={({ elementRef, resizedObservedHeadRef, resizedObservedBodyRef }) => (
+            <>
+              <div className="compare-products__head" role="rowgroup">
+                {productDetailsHeadersKeys.map((detailHeader, headerIndex) => (
+                  <div
+                    className={`${getClassForNameHeader(headerIndex)}`}
+                    ref={resizedObservedHeadRef}
+                    role="row"
+                    key={`header-row-${headerIndex}`}
+                  >
+                    <span className="compare-products__cell" role="cell">
+                      {headerIndex === 0 ? getProductsAmountText() : productDetailsHeaders[detailHeader]}
+                    </span>
+                  </div>
+                ))}
+              </div>
 
-            return (
-              <>
-                <div className="compare-products__head">
-                  {productDetailsHeadersKeys.map((detailHeader, index) => (
-                    <div className="compare-products__cell" ref={resizedObservedHeadRef} key={`header-row-${index}`}>
-                      {productDetailsHeaders[detailHeader]}
+              <div className="scrollable-parent">
+                <div className="compare-products__body" ref={elementRef} role="rowgroup">
+                  {productDetailsHeadersKeys.map((detailHeader, headerIndex) => (
+                    <div
+                      className={`compare-products__row ${getClassForNameHeader(headerIndex)}`}
+                      ref={resizedObservedBodyRef}
+                      role="row"
+                      key={`body-row-${headerIndex}`}
+                    >
+                      {comparableProductsData.map((productData, dataIndex) => (
+                        <div className="compare-products__cell" role="cell" key={`cell-${dataIndex}`}>
+                          {prepareSpecificProductDetail(detailHeader, productData[detailHeader])}
+                        </div>
+                      ))}
                     </div>
                   ))}
                 </div>
-
-                <div className="scrollable-parent">
-                  <div className="compare-products__body" ref={elementRef}>
-                    {productDetailsHeadersKeys.map((detailHeader, headerIndex) => (
-                      <div
-                        className="compare-products__row"
-                        ref={resizedObservedBodyRef}
-                        key={`body-row-${headerIndex}`}
-                      >
-                        {comparableProductsData.map((productData, dataIndex) => (
-                          <div className="compare-products__cell" key={`cell-${dataIndex}`}>
-                            {prepareSpecificProductDetail(detailHeader, productData[detailHeader])}
-                          </div>
-                        ))}
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </>
-            );
-          }}
+              </div>
+            </>
+          )}
         />
       </div>
     </section>
   );
+
+  function prepareComparisonData(productDetailsHeaders) {
+    let productDetailsHeadersKeys = Object.keys(productDetailsHeaders).filter((header) => header !== 'relatedProducts');
+    let nameHeaderIndex = productDetailsHeadersKeys.findIndex((headerName) => headerName.toLowerCase() === 'name');
+    const comparableProductsData = appStore.productComparisonState.map((product) => getProductDetailsData(product));
+
+    const [nameHeader] = productDetailsHeadersKeys.splice(nameHeaderIndex, 1);
+    productDetailsHeadersKeys.unshift(nameHeader);
+    nameHeaderIndex = 0;
+
+    return { nameHeaderIndex, productDetailsHeaders, productDetailsHeadersKeys, comparableProductsData };
+  }
 }

--- a/src/frontend/components/pages/compare.js
+++ b/src/frontend/components/pages/compare.js
@@ -30,9 +30,41 @@ export default function Compare() {
     []
   );
 
-  useEffect(() => {
-    setTableStylingCSSVariables();
-  }, []);
+  const getTableHeadContent = (resizedObservedHeadRef) =>
+    function TableHeadContent(detailHeader, headerIndex) {
+      return (
+        <div
+          className={`${getClassForNameHeader(headerIndex)}`}
+          ref={resizedObservedHeadRef}
+          role="row"
+          key={`header-row-${headerIndex}`}
+        >
+          <span className="compare-products__cell" role="cell">
+            {headerIndex === 0 ? getProductsAmountText() : productDetailsHeaders[detailHeader]}
+          </span>
+        </div>
+      );
+    };
+
+  const getTableBodyContent = (resizedObservedBodyRef) =>
+    function TableBodyContent(detailHeader, headerIndex) {
+      return (
+        <div
+          className={`compare-products__row ${getClassForNameHeader(headerIndex)}`}
+          ref={resizedObservedBodyRef}
+          role="row"
+          key={`body-row-${headerIndex}`}
+        >
+          {comparableProductsData.map((productData, dataIndex) => (
+            <div className="compare-products__cell" role="cell" key={`cell-${dataIndex}`}>
+              {prepareSpecificProductDetail(detailHeader, productData[detailHeader])}
+            </div>
+          ))}
+        </div>
+      );
+    };
+
+  useEffect(setTableStylingCSSVariables, []);
 
   return (
     <section className="compare-products">
@@ -42,36 +74,12 @@ export default function Compare() {
           render={({ elementRef, resizedObservedHeadRef, resizedObservedBodyRef }) => (
             <>
               <div className="compare-products__head" role="rowgroup">
-                {productDetailsHeadersKeys.map((detailHeader, headerIndex) => (
-                  <div
-                    className={`${getClassForNameHeader(headerIndex)}`}
-                    ref={resizedObservedHeadRef}
-                    role="row"
-                    key={`header-row-${headerIndex}`}
-                  >
-                    <span className="compare-products__cell" role="cell">
-                      {headerIndex === 0 ? getProductsAmountText() : productDetailsHeaders[detailHeader]}
-                    </span>
-                  </div>
-                ))}
+                {productDetailsHeadersKeys.map(getTableHeadContent(resizedObservedHeadRef))}
               </div>
 
-              <div className="scrollable-parent">
+              <div>
                 <div className="compare-products__body" ref={elementRef} role="rowgroup">
-                  {productDetailsHeadersKeys.map((detailHeader, headerIndex) => (
-                    <div
-                      className={`compare-products__row ${getClassForNameHeader(headerIndex)}`}
-                      ref={resizedObservedBodyRef}
-                      role="row"
-                      key={`body-row-${headerIndex}`}
-                    >
-                      {comparableProductsData.map((productData, dataIndex) => (
-                        <div className="compare-products__cell" role="cell" key={`cell-${dataIndex}`}>
-                          {prepareSpecificProductDetail(detailHeader, productData[detailHeader])}
-                        </div>
-                      ))}
-                    </div>
-                  ))}
+                  {productDetailsHeadersKeys.map(getTableBodyContent(resizedObservedBodyRef))}
                 </div>
               </div>
             </>

--- a/src/frontend/components/pages/compare.js
+++ b/src/frontend/components/pages/compare.js
@@ -1,18 +1,17 @@
 import React from 'react';
 import appStore from '../../features/appStore';
+import ProductDetails from '../views/productDetails';
 
 export default function Compare() {
   return (
-    <section>
-      <ol>
-        {appStore.productComparisonState.map((product) => {
-          return (
-            <li key={product._id} className="compare-products__list-item">
-              <span>{product.name}</span>
-            </li>
-          );
-        })}
-      </ol>
-    </section>
+    <ol className="compare-products-list">
+      {appStore.productComparisonState.map((product) => {
+        return (
+          <li key={product._id} className="compare-products-list__item">
+            <ProductDetails product={product} />
+          </li>
+        );
+      })}
+    </ol>
   );
 }

--- a/src/frontend/components/pages/compare.js
+++ b/src/frontend/components/pages/compare.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import appStore from '../../features/appStore';
+
+export default function Compare() {
+  return (
+    <section>
+      <ol>
+        {appStore.productComparisonState.map((product) => {
+          return (
+            <li key={product._id} className="compare-products__list-item">
+              <span>{product.name}</span>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}

--- a/src/frontend/components/pages/compare.js
+++ b/src/frontend/components/pages/compare.js
@@ -30,12 +30,12 @@ export default function Compare() {
     []
   );
 
-  const getTableHeadContent = (resizedObservedHeadRef) =>
+  const getTableHeadContent = (headRowRefGetter) =>
     function TableHeadContent(detailHeader, headerIndex) {
       return (
         <div
           className={`${getClassForNameHeader(headerIndex)}`}
-          ref={resizedObservedHeadRef}
+          ref={headRowRefGetter}
           role="row"
           key={`header-row-${headerIndex}`}
         >
@@ -46,12 +46,12 @@ export default function Compare() {
       );
     };
 
-  const getTableBodyContent = (resizedObservedBodyRef) =>
+  const getTableBodyContent = (bodyRowRefGetter) =>
     function TableBodyContent(detailHeader, headerIndex) {
       return (
         <div
           className={`compare-products__row ${getClassForNameHeader(headerIndex)}`}
-          ref={resizedObservedBodyRef}
+          ref={bodyRowRefGetter}
           role="row"
           key={`body-row-${headerIndex}`}
         >
@@ -71,15 +71,15 @@ export default function Compare() {
       <div ref={tableRef} className="compare-products__table" role="table">
         <Scroller
           forwardProps={{ productDetailsHeadersKeys }}
-          render={({ elementRef, resizedObservedHeadRef, resizedObservedBodyRef }) => (
+          render={({ elementRef, headRowRefGetter, bodyRowRefGetter }) => (
             <>
               <div className="compare-products__head" role="rowgroup">
-                {productDetailsHeadersKeys.map(getTableHeadContent(resizedObservedHeadRef))}
+                {productDetailsHeadersKeys.map(getTableHeadContent(headRowRefGetter))}
               </div>
 
               <div>
                 <div className="compare-products__body" ref={elementRef} role="rowgroup">
-                  {productDetailsHeadersKeys.map(getTableBodyContent(resizedObservedBodyRef))}
+                  {productDetailsHeadersKeys.map(getTableBodyContent(bodyRowRefGetter))}
                 </div>
               </div>
             </>

--- a/src/frontend/components/pages/compare.js
+++ b/src/frontend/components/pages/compare.js
@@ -8,7 +8,7 @@ export default function Compare() {
     <section className="compare-products">
       <Scroller
         render={(listRef) => (
-          <ol ref={listRef} className="compare-products-list">
+          <ol ref={listRef} data-scrollable="true" className="compare-products-list">
             {appStore.productComparisonState.map((product) => {
               return (
                 <li key={product._id} className="compare-products-list__item">

--- a/src/frontend/components/pages/compare.js
+++ b/src/frontend/components/pages/compare.js
@@ -78,6 +78,10 @@ export default function Compare() {
     <section className="compare-products">
       <div ref={tableRef} className="compare-products__table" role="table">
         <Scroller
+          scrollerBaseValueMeta={{
+            selector: '.compare-products-candidates, .compare-products',
+            varName: '--product-list-item-width',
+          }}
           render={({ elementRef, multipleRefsGetter }) => {
             const { createRefGetter, REF_TYPE } = multipleRefsGetter;
             const [headRowRefGetter, bodyRowRefGetter] = [

--- a/src/frontend/components/utils/scroller.js
+++ b/src/frontend/components/utils/scroller.js
@@ -13,8 +13,8 @@ function ScrollButton({ directionPointer, handleClick, isVisible, isDisabled, te
   );
 }
 
-export default function Scroller({ render }) {
-  const [listRef, setListRef] = useState(createRef());
+export default function Scroller({ render, forwardProps }) {
+  const [elementRef] = useState(createRef());
   const [scrollingBtnVisible, setScrollingBtnVisible] = useState(false);
   const [leftBtnDisabled, setLeftBtnDisabled] = useState(true);
   const [rightBtnDisabled, setRightBtnDisabled] = useState(false);
@@ -26,42 +26,37 @@ export default function Scroller({ render }) {
   const SCROLL_DIRECTION = { LEFT: 1, RIGHT: -1 };
 
   useEffect(() => {
-    checkIfElementOverflows(true);
     window.addEventListener('resize', checkIfElementOverflows);
-    listRef.current.addEventListener('transitionend', handleElementToParentOffsetChange);
+    elementRef.current.addEventListener('transitionend', handleElementToParentOffsetChange);
+    elementRef.current.dataset.scrollable = 'true';
+
+    checkIfElementOverflows();
 
     return () => {
       window.removeEventListener('resize', checkIfElementOverflows);
-      listRef.current.removeEventListener('transitionend', handleElementToParentOffsetChange);
+      elementRef.current.removeEventListener('transitionend', handleElementToParentOffsetChange);
     };
   }, []);
 
-  useEffect(() => {
-    if (!listRef.current) {
-      setListRef(createRef());
-    }
-  });
-
-  const checkIfElementOverflows = (ignoreHandlingOffset) => {
-    const target = listRef.current.parentNode;
+  const checkIfElementOverflows = (resizeEvent) => {
+    const target = elementRef.current.parentNode;
     const doesElementOverflow = target.clientWidth < target.scrollWidth;
 
     scrollToDirection(null, SCROLL_VARIABLE.LEFT_EDGE);
-    toggleScrollButtons(doesElementOverflow, ignoreHandlingOffset);
+    toggleScrollButtons(doesElementOverflow, resizeEvent);
   };
 
-  const toggleScrollButtons = (showScrollingButtons, ignoreHandlingOffset) => {
+  const toggleScrollButtons = (showScrollingButtons, resizeEvent) => {
     setScrollingBtnVisible(showScrollingButtons);
 
-    if (!ignoreHandlingOffset) {
+    if (resizeEvent) {
       handleElementToParentOffsetChange();
     }
   };
 
   const handleElementToParentOffsetChange = () => {
-    const elementRef = listRef.current;
-    const { left: elementLeftOffset, right: elementRightOffset } = elementRef.getBoundingClientRect();
-    const { left: parentLeftOffset, right: parentRightOffset } = elementRef.parentNode.getBoundingClientRect();
+    const { left: elementLeftOffset, right: elementRightOffset } = elementRef.current.getBoundingClientRect();
+    const { left: parentLeftOffset, right: parentRightOffset } = elementRef.current.parentNode.getBoundingClientRect();
     const leftOffsetGreaterThanParent = Math.round(elementLeftOffset) >= Math.round(parentLeftOffset);
     const rightOffsetLessThanParent = Math.round(elementRightOffset) <= Math.round(parentRightOffset);
 
@@ -71,18 +66,18 @@ export default function Scroller({ render }) {
     if (leftOffsetGreaterThanParent) {
       scrollToDirection(null, SCROLL_VARIABLE.LEFT_EDGE);
     } else if (rightOffsetLessThanParent) {
-      const rightEdge = elementRef.parentNode.offsetWidth - elementRef.offsetWidth;
+      const rightEdge = elementRef.current.parentNode.offsetWidth - elementRef.current.offsetWidth;
       scrollToDirection(null, rightEdge);
     }
   };
 
   const scrollToDirection = (direction, value) => {
-    const oldScrollValue = Number(listRef.current.style.getPropertyValue(SCROLL_VARIABLE.NAME));
+    const oldScrollValue = Number(elementRef.current.style.getPropertyValue(SCROLL_VARIABLE.NAME));
     const newScrollValue = oldScrollValue + SCROLL_VARIABLE.BASE_VALUE * direction;
 
     const scrollValue = direction === null ? value : newScrollValue;
 
-    listRef.current.style.setProperty(SCROLL_VARIABLE.NAME, scrollValue);
+    elementRef.current.style.setProperty(SCROLL_VARIABLE.NAME, scrollValue);
   };
 
   return (
@@ -94,7 +89,7 @@ export default function Scroller({ render }) {
         text={'&larr;'}
         handleClick={scrollToDirection}
       />
-      <div className="scrollable">{render(listRef)}</div>
+      <div>{render(elementRef, forwardProps)}</div>
       <ScrollButton
         directionPointer={SCROLL_DIRECTION.RIGHT}
         isVisible={scrollingBtnVisible}

--- a/src/frontend/components/utils/scroller.js
+++ b/src/frontend/components/utils/scroller.js
@@ -1,24 +1,11 @@
 import React, { createRef, useEffect, useState } from 'react';
 
-const SCROLL_DIRECTION = { LEFT: -1, RIGHT: 1 };
-
-function ScrollButton({ elementToScroll, directionPointer, isVisible, text }) {
-  const SCROLL_VARIABLE = {
-    NAME: '--scrollValue',
-    BASE_VALUE: 15,
-  };
-
-  const scrollToDirection = () => {
-    const oldScrollValue = Number(elementToScroll.style.getPropertyValue(SCROLL_VARIABLE.NAME));
-    const newScrollValue = oldScrollValue + SCROLL_VARIABLE.BASE_VALUE * directionPointer;
-
-    elementToScroll.style.setProperty(SCROLL_VARIABLE.NAME, newScrollValue);
-  };
-
+function ScrollButton({ directionPointer, handleClick, isVisible, isDisabled, text }) {
   return (
     <button
-      onClick={scrollToDirection}
+      onClick={() => handleClick(directionPointer)}
       className={`scroller-btn ${isVisible ? 'scroller-btn--visible' : ''}`}
+      disabled={isDisabled}
       dangerouslySetInnerHTML={{
         __html: text,
       }}
@@ -29,13 +16,23 @@ function ScrollButton({ elementToScroll, directionPointer, isVisible, text }) {
 export default function Scroller({ render }) {
   const [listRef, setListRef] = useState(createRef());
   const [scrollingBtnVisible, setScrollingBtnVisible] = useState(false);
+  const [leftBtnDisabled, setLeftBtnDisabled] = useState(true);
+  const [rightBtnDisabled, setRightBtnDisabled] = useState(false);
+  const SCROLL_VARIABLE = {
+    NAME: '--scrollValue',
+    BASE_VALUE: 15,
+    LEFT_EDGE: 0,
+  };
+  const SCROLL_DIRECTION = { LEFT: 1, RIGHT: -1 };
 
   useEffect(() => {
-    checkIfElementOverflows();
+    checkIfElementOverflows(true);
     window.addEventListener('resize', checkIfElementOverflows);
+    listRef.current.addEventListener('transitionend', handleElementToParentOffsetChange);
 
     return () => {
       window.removeEventListener('resize', checkIfElementOverflows);
+      listRef.current.removeEventListener('transitionend', handleElementToParentOffsetChange);
     };
   }, []);
 
@@ -45,31 +42,65 @@ export default function Scroller({ render }) {
     }
   });
 
-  const checkIfElementOverflows = () => {
+  const checkIfElementOverflows = (ignoreHandlingOffset) => {
     const target = listRef.current.parentNode;
     const doesElementOverflow = target.clientWidth < target.scrollWidth;
 
-    toggleScrollButtons(doesElementOverflow);
+    scrollToDirection(null, SCROLL_VARIABLE.LEFT_EDGE);
+    toggleScrollButtons(doesElementOverflow, ignoreHandlingOffset);
   };
 
-  const toggleScrollButtons = (showScrollingButtons) => {
+  const toggleScrollButtons = (showScrollingButtons, ignoreHandlingOffset) => {
     setScrollingBtnVisible(showScrollingButtons);
+
+    if (!ignoreHandlingOffset) {
+      handleElementToParentOffsetChange();
+    }
+  };
+
+  const handleElementToParentOffsetChange = () => {
+    const elementRef = listRef.current;
+    const { left: elementLeftOffset, right: elementRightOffset } = elementRef.getBoundingClientRect();
+    const { left: parentLeftOffset, right: parentRightOffset } = elementRef.parentNode.getBoundingClientRect();
+    const leftOffsetGreaterThanParent = Math.round(elementLeftOffset) >= Math.round(parentLeftOffset);
+    const rightOffsetLessThanParent = Math.round(elementRightOffset) <= Math.round(parentRightOffset);
+
+    setLeftBtnDisabled(leftOffsetGreaterThanParent);
+    setRightBtnDisabled(rightOffsetLessThanParent);
+
+    if (leftOffsetGreaterThanParent) {
+      scrollToDirection(null, SCROLL_VARIABLE.LEFT_EDGE);
+    } else if (rightOffsetLessThanParent) {
+      const rightEdge = elementRef.parentNode.offsetWidth - elementRef.offsetWidth;
+      scrollToDirection(null, rightEdge);
+    }
+  };
+
+  const scrollToDirection = (direction, value) => {
+    const oldScrollValue = Number(listRef.current.style.getPropertyValue(SCROLL_VARIABLE.NAME));
+    const newScrollValue = oldScrollValue + SCROLL_VARIABLE.BASE_VALUE * direction;
+
+    const scrollValue = direction === null ? value : newScrollValue;
+
+    listRef.current.style.setProperty(SCROLL_VARIABLE.NAME, scrollValue);
   };
 
   return (
     <>
       <ScrollButton
-        elementToScroll={listRef.current}
         directionPointer={SCROLL_DIRECTION.LEFT}
         isVisible={scrollingBtnVisible}
+        isDisabled={leftBtnDisabled}
         text={'&larr;'}
+        handleClick={scrollToDirection}
       />
       <div className="scrollable">{render(listRef)}</div>
       <ScrollButton
-        elementToScroll={listRef.current}
         directionPointer={SCROLL_DIRECTION.RIGHT}
         isVisible={scrollingBtnVisible}
+        isDisabled={rightBtnDisabled}
         text={'&rarr;'}
+        handleClick={scrollToDirection}
       />
     </>
   );

--- a/src/frontend/components/utils/scroller.js
+++ b/src/frontend/components/utils/scroller.js
@@ -18,8 +18,8 @@ export default function Scroller({ render, forwardProps }) {
   const [scrollingBtnVisible, setScrollingBtnVisible] = useState(false);
   const [leftBtnDisabled, setLeftBtnDisabled] = useState(true);
   const [rightBtnDisabled, setRightBtnDisabled] = useState(false);
-  const headRefs = useRef([]);
-  const bodyRefs = useRef([]);
+  const headRowRefs = useRef([]);
+  const bodyRowRefs = useRef([]);
   const resizeObserverRef = useRef(null);
 
   const REF_TYPE = {
@@ -56,9 +56,9 @@ export default function Scroller({ render, forwardProps }) {
       }
 
       if (refType === REF_TYPE.HEAD) {
-        updateHeadOrBodyRefs(headRefs, ref);
+        updateHeadOrBodyRefs(headRowRefs, ref);
       } else if (refType === REF_TYPE.BODY) {
-        updateHeadOrBodyRefs(bodyRefs, ref);
+        updateHeadOrBodyRefs(bodyRowRefs, ref);
       } else {
         throw TypeError(`Got incorrect "refType" variable "${refType}"!`);
       }
@@ -75,26 +75,27 @@ export default function Scroller({ render, forwardProps }) {
 
   const setupResizeObserver = () => {
     if (
-      headRefs.current.length > 0 &&
-      bodyRefs.current.length > 0 &&
-      headRefs.current.length === bodyRefs.current.length
+      headRowRefs.current.length > 0 &&
+      bodyRowRefs.current.length > 0 &&
+      headRowRefs.current.length === bodyRowRefs.current.length
     ) {
-      resizeObserverRef.current = new window.ResizeObserver((entries) => {
-        const refIndexes = bodyRefs.current
+      const equalizeTableHeaderRowsHeightToAssociatedBodyRows = (entries) => {
+        const refIndexes = bodyRowRefs.current
           .map((ref) => entries.findIndex(({ target }) => target === ref))
           .filter((refIndex) => refIndex > -1);
 
         refIndexes.forEach((refIndex) => {
-          headRefs.current[refIndex].style.height = `${bodyRefs.current[refIndex].clientHeight}px`;
+          headRowRefs.current[refIndex].style.height = `${bodyRowRefs.current[refIndex].clientHeight}px`;
         });
-      });
+      };
 
-      bodyRefs.current.forEach((element) => resizeObserverRef.current.observe(element));
+      resizeObserverRef.current = new window.ResizeObserver(equalizeTableHeaderRowsHeightToAssociatedBodyRows);
+      bodyRowRefs.current.forEach((bodyRow) => resizeObserverRef.current.observe(bodyRow));
     } else {
       throw Error(
-        `headRefs or bodyRefs are empty or have different sizes. headRefs: ${[...headRefs.current]}, bodyRefs: ${[
-          ...bodyRefs.current,
-        ]}`
+        `headRowRefs or bodyRowRefs are empty or have different sizes. headRowRefs: ${[
+          ...headRowRefs.current,
+        ]}, bodyRowRefs: ${[...bodyRowRefs.current]}`
       );
     }
   };
@@ -153,8 +154,8 @@ export default function Scroller({ render, forwardProps }) {
       {render({
         elementRef,
         forwardProps,
-        resizedObservedHeadRef: createRefGetter(REF_TYPE.HEAD),
-        resizedObservedBodyRef: createRefGetter(REF_TYPE.BODY),
+        headRowRefGetter: createRefGetter(REF_TYPE.HEAD),
+        bodyRowRefGetter: createRefGetter(REF_TYPE.BODY),
       })}
       <ScrollButton
         directionPointer={SCROLL_DIRECTION.RIGHT}

--- a/src/frontend/components/utils/scroller.js
+++ b/src/frontend/components/utils/scroller.js
@@ -1,5 +1,25 @@
 import React, { createRef, useMemo, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
+const getScrollBaseValue = ({ selector = '', varName = '' } = {}) => {
+  if (typeof selector !== 'string' || selector.length === 0 || typeof varName !== 'string' || varName.length === 0) {
+    return NaN;
+  }
+
+  for (const sheet of document.styleSheets) {
+    const scrollerBaseValue = [...sheet.cssRules].find(
+      (rule) => rule.selectorText === selector && rule.style && [...rule.style].includes(varName)
+    );
+
+    if (scrollerBaseValue) {
+      return Number.parseInt(scrollerBaseValue.style.getPropertyValue(varName));
+    }
+  }
+
+  throw Error(
+    `Values of {selector: '${selector}'} and {varName: '${varName}'} were not matched in any CSS on the page!`
+  );
+};
+
 function ScrollButton({ directionPointer, handleClick, isVisible, isDisabled, text }) {
   return (
     <button
@@ -13,7 +33,7 @@ function ScrollButton({ directionPointer, handleClick, isVisible, isDisabled, te
   );
 }
 
-export default function Scroller({ render, forwardProps }) {
+export default function Scroller({ render, scrollerBaseValueMeta, forwardProps }) {
   const [elementRef] = useState(createRef());
   const [scrollingBtnVisible, setScrollingBtnVisible] = useState(false);
   const [leftBtnDisabled, setLeftBtnDisabled] = useState(true);
@@ -33,6 +53,7 @@ export default function Scroller({ render, forwardProps }) {
     };
   }, []);
   const [multipleRefsGetterUsed, setMultipleRefsGetterUsed] = useState(false);
+  const scrollBaseValue = useMemo(() => getScrollBaseValue(scrollerBaseValueMeta), []);
 
   const REF_TYPE = Object.freeze({
     HEAD: 'head',
@@ -40,7 +61,7 @@ export default function Scroller({ render, forwardProps }) {
   });
   const SCROLL_VARIABLE = {
     NAME: '--scrollValue',
-    BASE_VALUE: 15,
+    BASE_VALUE: scrollBaseValue || 15,
     LEFT_EDGE: 0,
   };
   const SCROLL_DIRECTION = { LEFT: 1, RIGHT: -1 };

--- a/src/frontend/components/utils/scroller.js
+++ b/src/frontend/components/utils/scroller.js
@@ -37,6 +37,7 @@ export default function Scroller({ render, forwardProps }) {
     window.addEventListener('resize', checkIfElementOverflows);
     elementRef.current.addEventListener('transitionend', handleElementToParentOffsetChange);
     elementRef.current.dataset.scrollable = 'true';
+    elementRef.current.parentNode.dataset.scrollableParent = 'true';
 
     setupResizeObserver();
     checkIfElementOverflows();
@@ -48,26 +49,28 @@ export default function Scroller({ render, forwardProps }) {
     };
   }, []);
 
-  const createRefGetter = (type) => {
-    return (ref) => {
+  const createRefGetter = (refType) => {
+    return function refGetter(ref) {
       if (!ref) {
         return null;
       }
 
-      if (type === REF_TYPE.HEAD) {
-        if (!headRefs.current.some((hRef) => hRef === ref)) {
-          headRefs.current = headRefs.current.concat(ref);
-        }
-      } else if (type === REF_TYPE.BODY) {
-        if (!bodyRefs.current.some((bRef) => bRef === ref)) {
-          bodyRefs.current = bodyRefs.current.concat(ref);
-        }
+      if (refType === REF_TYPE.HEAD) {
+        updateHeadOrBodyRefs(headRefs, ref);
+      } else if (refType === REF_TYPE.BODY) {
+        updateHeadOrBodyRefs(bodyRefs, ref);
       } else {
-        throw TypeError(`Got incorrect "type" variable "${type}"!`);
+        throw TypeError(`Got incorrect "refType" variable "${refType}"!`);
       }
 
       return ref;
     };
+
+    function updateHeadOrBodyRefs(refs, ref) {
+      if (!refs.current.some((refOfType) => refOfType === ref)) {
+        refs.current = refs.current.concat(ref);
+      }
+    }
   };
 
   const setupResizeObserver = () => {

--- a/src/frontend/components/utils/scroller.js
+++ b/src/frontend/components/utils/scroller.js
@@ -1,4 +1,4 @@
-import React, { createRef, useEffect, useState } from 'react';
+import React, { createRef, useCallback, useEffect, useRef, useState } from 'react';
 
 function ScrollButton({ directionPointer, handleClick, isVisible, isDisabled, text }) {
   return (
@@ -18,6 +18,8 @@ export default function Scroller({ render, forwardProps }) {
   const [scrollingBtnVisible, setScrollingBtnVisible] = useState(false);
   const [leftBtnDisabled, setLeftBtnDisabled] = useState(true);
   const [rightBtnDisabled, setRightBtnDisabled] = useState(false);
+  const resizedObservedRefs = useRef([]);
+
   const SCROLL_VARIABLE = {
     NAME: '--scrollValue',
     BASE_VALUE: 15,
@@ -30,12 +32,24 @@ export default function Scroller({ render, forwardProps }) {
     elementRef.current.addEventListener('transitionend', handleElementToParentOffsetChange);
     elementRef.current.dataset.scrollable = 'true';
 
+    console.warn('resizedObservedRefs:', resizedObservedRefs);
+
     checkIfElementOverflows();
 
     return () => {
       window.removeEventListener('resize', checkIfElementOverflows);
       elementRef.current.removeEventListener('transitionend', handleElementToParentOffsetChange);
     };
+  }, []);
+
+  const resizedObservedRef = useCallback((ref) => {
+    // const refIndex = [...ref.parentNode.children].findIndex(child => child === ref);
+    resizedObservedRefs.current = resizedObservedRefs.current.concat({
+      body: ref,
+      header: null,
+    });
+
+    return ref;
   }, []);
 
   const checkIfElementOverflows = (resizeEvent) => {
@@ -89,7 +103,7 @@ export default function Scroller({ render, forwardProps }) {
         text={'&larr;'}
         handleClick={scrollToDirection}
       />
-      <div>{render(elementRef, forwardProps)}</div>
+      {render({ elementRef, forwardProps, resizedObservedRef })}
       <ScrollButton
         directionPointer={SCROLL_DIRECTION.RIGHT}
         isVisible={scrollingBtnVisible}

--- a/src/frontend/components/utils/scroller.js
+++ b/src/frontend/components/utils/scroller.js
@@ -1,5 +1,31 @@
 import React, { createRef, useEffect, useState } from 'react';
 
+const SCROLL_DIRECTION = { LEFT: -1, RIGHT: 1 };
+
+function ScrollButton({ elementToScroll, directionPointer, isVisible, text }) {
+  const SCROLL_VARIABLE = {
+    NAME: '--scrollValue',
+    BASE_VALUE: 15,
+  };
+
+  const scrollToDirection = () => {
+    const oldScrollValue = Number(elementToScroll.style.getPropertyValue(SCROLL_VARIABLE.NAME));
+    const newScrollValue = oldScrollValue + SCROLL_VARIABLE.BASE_VALUE * directionPointer;
+
+    elementToScroll.style.setProperty(SCROLL_VARIABLE.NAME, newScrollValue);
+  };
+
+  return (
+    <button
+      onClick={scrollToDirection}
+      className={`scroller-btn ${isVisible ? 'scroller-btn--visible' : ''}`}
+      dangerouslySetInnerHTML={{
+        __html: text,
+      }}
+    />
+  );
+}
+
 export default function Scroller({ render }) {
   const [listRef, setListRef] = useState(createRef());
   const [scrollingBtnVisible, setScrollingBtnVisible] = useState(false);
@@ -14,8 +40,6 @@ export default function Scroller({ render }) {
   }, []);
 
   useEffect(() => {
-    console.log('? listRef:', listRef);
-
     if (!listRef.current) {
       setListRef(createRef());
     }
@@ -25,35 +49,28 @@ export default function Scroller({ render }) {
     const target = listRef.current.parentNode;
     const doesElementOverflow = target.clientWidth < target.scrollWidth;
 
-    if (doesElementOverflow) {
-      console.log('overflow happens...');
-    }
-
     toggleScrollButtons(doesElementOverflow);
-
-    // console.log(
-    //   'on resize... /listRef:',
-    //   listRef.current,
-    //   ' /parent clientWidth: ',
-    //   listRef.current.parentNode.clientWidth,
-    //   ' /parent scrollWidth:',
-    //   listRef.current.parentNode.scrollWidth
-    // );
   };
 
   const toggleScrollButtons = (showScrollingButtons) => {
-    console.log('showScrollingButtons?', showScrollingButtons);
-
-    // if (showScrollingButtons !== scrollingBtnVisible) {
     setScrollingBtnVisible(showScrollingButtons);
-    // }
   };
 
   return (
     <>
-      <button className={`scroller-btn ${scrollingBtnVisible ? 'scroller-btn--visible' : ''}`}>&larr;</button>
-      {render(listRef)}
-      <button className={`scroller-btn ${scrollingBtnVisible ? 'scroller-btn--visible' : ''}`}>&rarr;</button>
+      <ScrollButton
+        elementToScroll={listRef.current}
+        directionPointer={SCROLL_DIRECTION.LEFT}
+        isVisible={scrollingBtnVisible}
+        text={'&larr;'}
+      />
+      <div className="scrollable">{render(listRef)}</div>
+      <ScrollButton
+        elementToScroll={listRef.current}
+        directionPointer={SCROLL_DIRECTION.RIGHT}
+        isVisible={scrollingBtnVisible}
+        text={'&rarr;'}
+      />
     </>
   );
 }

--- a/src/frontend/components/utils/scroller.js
+++ b/src/frontend/components/utils/scroller.js
@@ -38,8 +38,6 @@ export default function Scroller({ render, forwardProps }) {
     elementRef.current.addEventListener('transitionend', handleElementToParentOffsetChange);
     elementRef.current.dataset.scrollable = 'true';
 
-    console.warn('headRefs:', headRefs, ' /bodyRefs:', bodyRefs);
-
     setupResizeObserver();
     checkIfElementOverflows();
 
@@ -79,8 +77,6 @@ export default function Scroller({ render, forwardProps }) {
       headRefs.current.length === bodyRefs.current.length
     ) {
       resizeObserverRef.current = new window.ResizeObserver((entries) => {
-        // console.log('entries:', entries);
-
         const refIndexes = bodyRefs.current
           .map((ref) => entries.findIndex(({ target }) => target === ref))
           .filter((refIndex) => refIndex > -1);

--- a/src/frontend/components/utils/scroller.js
+++ b/src/frontend/components/utils/scroller.js
@@ -1,0 +1,59 @@
+import React, { createRef, useEffect, useState } from 'react';
+
+export default function Scroller({ render }) {
+  const [listRef, setListRef] = useState(createRef());
+  const [scrollingBtnVisible, setScrollingBtnVisible] = useState(false);
+
+  useEffect(() => {
+    checkIfElementOverflows();
+    window.addEventListener('resize', checkIfElementOverflows);
+
+    return () => {
+      window.removeEventListener('resize', checkIfElementOverflows);
+    };
+  }, []);
+
+  useEffect(() => {
+    console.log('? listRef:', listRef);
+
+    if (!listRef.current) {
+      setListRef(createRef());
+    }
+  });
+
+  const checkIfElementOverflows = () => {
+    const target = listRef.current.parentNode;
+    const doesElementOverflow = target.clientWidth < target.scrollWidth;
+
+    if (doesElementOverflow) {
+      console.log('overflow happens...');
+    }
+
+    toggleScrollButtons(doesElementOverflow);
+
+    // console.log(
+    //   'on resize... /listRef:',
+    //   listRef.current,
+    //   ' /parent clientWidth: ',
+    //   listRef.current.parentNode.clientWidth,
+    //   ' /parent scrollWidth:',
+    //   listRef.current.parentNode.scrollWidth
+    // );
+  };
+
+  const toggleScrollButtons = (showScrollingButtons) => {
+    console.log('showScrollingButtons?', showScrollingButtons);
+
+    // if (showScrollingButtons !== scrollingBtnVisible) {
+    setScrollingBtnVisible(showScrollingButtons);
+    // }
+  };
+
+  return (
+    <>
+      <button className={`scroller-btn ${scrollingBtnVisible ? 'scroller-btn--visible' : ''}`}>&larr;</button>
+      {render(listRef)}
+      <button className={`scroller-btn ${scrollingBtnVisible ? 'scroller-btn--visible' : ''}`}>&rarr;</button>
+    </>
+  );
+}

--- a/src/frontend/components/views/compareProducts.js
+++ b/src/frontend/components/views/compareProducts.js
@@ -20,6 +20,7 @@ export const CompareProductsList = observer(function CompareProducts() {
   };
 
   return (
+    // TODO: shrink/collapse widget to an expandable button on mobile
     <aside className="compare-products-candidates">
       <ol className="compare-products-candidates__list">
         {appStore.productComparisonState.map((product, index) => {
@@ -36,8 +37,10 @@ export const CompareProductsList = observer(function CompareProducts() {
         })}
       </ol>
 
-      <Link to={{ pathname: `/compare` }}> {translations.compareProducts}</Link>
-      <button onClick={handleClearCompareProducts}>{translations.clearComparableProducts}</button>
+      <div className="compare-products-candidates__actions">
+        <Link to={{ pathname: `/compare` }}> {translations.compareProducts}</Link>
+        <button onClick={handleClearCompareProducts}>{translations.clearComparableProducts}</button>
+      </div>
     </aside>
   );
 });

--- a/src/frontend/components/views/compareProducts.js
+++ b/src/frontend/components/views/compareProducts.js
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
+import { toJS } from 'mobx';
 import { observer } from 'mobx-react';
 import { autorun } from 'mobx';
 import appStore from '../../features/appStore';
 import { Link } from 'react-router-dom';
+import Scroller from '../utils/scroller';
 
 const List = observer(function CompareProducts() {
   const translations = {
@@ -22,14 +24,23 @@ const List = observer(function CompareProducts() {
   return (
     // TODO: shrink/collapse widget to an expandable button on mobile
     <aside className="compare-products-candidates">
-      <ol className="compare-products-candidates__list">
-        {appStore.productComparisonState.map((product, index) => (
-          <li key={product._id} className="compare-products-candidates__list-item">
-            <span>{product.name}</span>
-            <button onClick={() => handleRemoveComparableProduct(index)}>{translations.removeComparableProduct}</button>
-          </li>
-        ))}
-      </ol>
+      <Scroller
+        forwardProps={{ trackedChanges: toJS(appStore.productComparisonState) }}
+        render={({ elementRef, forwardProps: { trackedChanges: productComparisonState } }) => (
+          <div>
+            <ol ref={elementRef} className="compare-products-candidates__list">
+              {productComparisonState.map((product, index) => (
+                <li className="compare-products-candidates__list-item" key={product._id}>
+                  <span>{product.name}</span>
+                  <button onClick={() => handleRemoveComparableProduct(index)}>
+                    {translations.removeComparableProduct}
+                  </button>
+                </li>
+              ))}
+            </ol>
+          </div>
+        )}
+      />
 
       <div className="compare-products-candidates__actions">
         <Link to={{ pathname: `/compare` }}> {translations.compareProducts}</Link>

--- a/src/frontend/components/views/compareProducts.js
+++ b/src/frontend/components/views/compareProducts.js
@@ -21,10 +21,17 @@ const List = observer(function CompareProducts() {
     appStore.clearProductComparisonState();
   };
 
-  return (
-    // TODO: shrink/collapse widget to an expandable button on mobile
+  return appStore.productComparisonState.length ? (
+    /** TODO:
+     * - shrink/collapse widget to an expandable button on mobile
+     * - mobile should have full width widget probably sticked to viewport's top
+     */
     <aside className="compare-products-candidates">
       <Scroller
+        scrollerBaseValueMeta={{
+          selector: '.compare-products-candidates, .compare-products',
+          varName: '--product-list-item-width',
+        }}
         forwardProps={{ trackedChanges: toJS(appStore.productComparisonState) }}
         render={({ elementRef, forwardProps: { trackedChanges: productComparisonState } }) => (
           <div>
@@ -47,6 +54,8 @@ const List = observer(function CompareProducts() {
         <button onClick={handleClearCompareProducts}>{translations.clearComparableProducts}</button>
       </div>
     </aside>
+  ) : (
+    ''
   );
 });
 

--- a/src/frontend/components/views/compareProducts.js
+++ b/src/frontend/components/views/compareProducts.js
@@ -4,7 +4,7 @@ import { autorun } from 'mobx';
 import appStore from '../../features/appStore';
 import { Link } from 'react-router-dom';
 
-export const CompareProductsList = observer(function CompareProducts() {
+const List = observer(function CompareProducts() {
   const translations = {
     compareProducts: 'Compare',
     removeComparableProduct: 'Remove',
@@ -45,7 +45,7 @@ export const CompareProductsList = observer(function CompareProducts() {
   );
 });
 
-export const ComparableProductToggler = observer(function ToggleProductComparable({ product }) {
+const Toggler = observer(function ToggleProductComparable({ product }) {
   const [isProductComparable, setIsProductComparable] = useState(false);
 
   const translations = {
@@ -77,3 +77,5 @@ export const ComparableProductToggler = observer(function ToggleProductComparabl
     </label>
   );
 });
+
+export default { List, Toggler };

--- a/src/frontend/components/views/compareProducts.js
+++ b/src/frontend/components/views/compareProducts.js
@@ -23,18 +23,12 @@ const List = observer(function CompareProducts() {
     // TODO: shrink/collapse widget to an expandable button on mobile
     <aside className="compare-products-candidates">
       <ol className="compare-products-candidates__list">
-        {appStore.productComparisonState.map((product, index) => {
-          console.log('product to compare...:', product);
-
-          return (
-            <li key={product._id} className="compare-products-candidates__list-item">
-              <span>{product.name}</span>
-              <button onClick={() => handleRemoveComparableProduct(index)}>
-                {translations.removeComparableProduct}
-              </button>
-            </li>
-          );
-        })}
+        {appStore.productComparisonState.map((product, index) => (
+          <li key={product._id} className="compare-products-candidates__list-item">
+            <span>{product.name}</span>
+            <button onClick={() => handleRemoveComparableProduct(index)}>{translations.removeComparableProduct}</button>
+          </li>
+        ))}
       </ol>
 
       <div className="compare-products-candidates__actions">

--- a/src/frontend/components/views/compareProducts.js
+++ b/src/frontend/components/views/compareProducts.js
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import { observer } from 'mobx-react';
+import { autorun } from 'mobx';
+import appStore from '../../features/appStore';
+
+export const CompareProductsList = observer(function CompareProducts() {
+  const translations = {
+    compareProducts: 'Compare',
+    removeComparableProduct: 'Remove',
+    clearComparableProducts: 'Clear',
+  };
+
+  const handleCompareSelectedProducts = () => {
+    console.log('comparable click...');
+  };
+
+  const handleRemoveComparableProduct = (productIndex) => {
+    appStore.updateProductComparisonState({ remove: { index: productIndex } });
+  };
+
+  const handleClearCompareProducts = () => {
+    appStore.clearProductComparisonState();
+  };
+
+  return (
+    <aside className="compare-products">
+      <ol className="compare-products__list">
+        {appStore.productComparisonState.map((product, index) => {
+          return (
+            <li key={product._id} className="compare-products__list-item">
+              <span>{product.name}</span>
+              <button onClick={() => handleRemoveComparableProduct(index)}>
+                {translations.removeComparableProduct}
+              </button>
+            </li>
+          );
+        })}
+      </ol>
+
+      <button onClick={handleCompareSelectedProducts}>{translations.compareProducts}</button>
+      <button onClick={handleClearCompareProducts}>{translations.clearComparableProducts}</button>
+    </aside>
+  );
+});
+
+export const ComparableProductToggler = observer(function ToggleProductComparable({ productData: { _id, name } }) {
+  const [isProductComparable, setIsProductComparable] = useState(false);
+
+  const translations = {
+    addToCompare: 'Add to compare',
+  };
+
+  autorun(() => {
+    const isComparable = appStore.productComparisonState.some((product) => product._id === _id);
+
+    if (isProductComparable !== isComparable) {
+      setIsProductComparable(isComparable);
+    }
+  });
+
+  const handleComparableToggle = ({ target }) => {
+    if (target.checked) {
+      appStore.updateProductComparisonState({ add: { _id, name } });
+    } else {
+      appStore.updateProductComparisonState({ remove: { _id } });
+    }
+  };
+
+  return (
+    <label className="product-list-item__toggle-comparable">
+      <span>{translations.addToCompare}</span>
+      <input type="checkbox" onChange={handleComparableToggle} checked={isProductComparable} />
+    </label>
+  );
+});

--- a/src/frontend/components/views/compareProducts.js
+++ b/src/frontend/components/views/compareProducts.js
@@ -20,11 +20,13 @@ export const CompareProductsList = observer(function CompareProducts() {
   };
 
   return (
-    <aside className="compare-products">
-      <ol className="compare-products__list">
+    <aside className="compare-products-candidates">
+      <ol className="compare-products-candidates__list">
         {appStore.productComparisonState.map((product, index) => {
+          console.log('product to compare...:', product);
+
           return (
-            <li key={product._id} className="compare-products__list-item">
+            <li key={product._id} className="compare-products-candidates__list-item">
               <span>{product.name}</span>
               <button onClick={() => handleRemoveComparableProduct(index)}>
                 {translations.removeComparableProduct}
@@ -40,7 +42,7 @@ export const CompareProductsList = observer(function CompareProducts() {
   );
 });
 
-export const ComparableProductToggler = observer(function ToggleProductComparable({ productData: { _id, name } }) {
+export const ComparableProductToggler = observer(function ToggleProductComparable({ product }) {
   const [isProductComparable, setIsProductComparable] = useState(false);
 
   const translations = {
@@ -48,7 +50,9 @@ export const ComparableProductToggler = observer(function ToggleProductComparabl
   };
 
   autorun(() => {
-    const isComparable = appStore.productComparisonState.some((product) => product._id === _id);
+    const isComparable = appStore.productComparisonState.some(
+      (comparableProduct) => comparableProduct._id === product._id
+    );
 
     if (isProductComparable !== isComparable) {
       setIsProductComparable(isComparable);
@@ -57,9 +61,9 @@ export const ComparableProductToggler = observer(function ToggleProductComparabl
 
   const handleComparableToggle = ({ target }) => {
     if (target.checked) {
-      appStore.updateProductComparisonState({ add: { _id, name } });
+      appStore.updateProductComparisonState({ add: product });
     } else {
-      appStore.updateProductComparisonState({ remove: { _id } });
+      appStore.updateProductComparisonState({ remove: { _id: product._id } });
     }
   };
 

--- a/src/frontend/components/views/compareProducts.js
+++ b/src/frontend/components/views/compareProducts.js
@@ -2,16 +2,13 @@ import React, { useState } from 'react';
 import { observer } from 'mobx-react';
 import { autorun } from 'mobx';
 import appStore from '../../features/appStore';
+import { Link } from 'react-router-dom';
 
 export const CompareProductsList = observer(function CompareProducts() {
   const translations = {
     compareProducts: 'Compare',
     removeComparableProduct: 'Remove',
     clearComparableProducts: 'Clear',
-  };
-
-  const handleCompareSelectedProducts = () => {
-    console.log('comparable click...');
   };
 
   const handleRemoveComparableProduct = (productIndex) => {
@@ -37,7 +34,7 @@ export const CompareProductsList = observer(function CompareProducts() {
         })}
       </ol>
 
-      <button onClick={handleCompareSelectedProducts}>{translations.compareProducts}</button>
+      <Link to={{ pathname: `/compare` }}> {translations.compareProducts}</Link>
       <button onClick={handleClearCompareProducts}>{translations.clearComparableProducts}</button>
     </aside>
   );

--- a/src/frontend/components/views/main.js
+++ b/src/frontend/components/views/main.js
@@ -6,6 +6,7 @@ import Shop from '../pages/shop';
 import NewProduct from '../pages/newProduct';
 import LogIn from '../pages/logIn';
 import Account from '../pages/account';
+import Compare from '../pages/compare';
 
 export default function Main() {
   return (
@@ -17,6 +18,9 @@ export default function Main() {
         </Route>
         <Route path="/shop">
           <Shop />
+        </Route>
+        <Route path="/compare">
+          <Compare />
         </Route>
         <Route path="/add-new-product">
           <NewProduct />

--- a/src/frontend/components/views/nav.js
+++ b/src/frontend/components/views/nav.js
@@ -32,7 +32,7 @@ export default observer(function Nav() {
           <Link to="/add-new-product">{translations.addNewProduct}</Link>
         </li>
         <li>
-          {appStore.getUserSessionState() === USER_SESSION_STATES.LOGGED_OUT ? (
+          {appStore.userSessionState === USER_SESSION_STATES.LOGGED_OUT ? (
             <Link to="/log-in">{translations.logIn}</Link>
           ) : (
             <Link to="/" onClick={logOut}>

--- a/src/frontend/components/views/productDetails.js
+++ b/src/frontend/components/views/productDetails.js
@@ -175,7 +175,7 @@ export function prepareSpecificProductDetail(detailName, detailValue, includeHea
     }
 
     default: {
-      console.error(`detailName '${detailName}' was not matched!`);
+      throw TypeError(`detailName '${detailName}' was not matched!`);
     }
   }
 }

--- a/src/frontend/components/views/productDetails.js
+++ b/src/frontend/components/views/productDetails.js
@@ -44,7 +44,7 @@ export default function ProductDetails({ product }) {
   const getShortDescriptionContent = () => {
     return (
       <>
-        <ul>
+        <ul className="compare-products-list__item-short-description">
           {product.shortDescription.map((description, index) => {
             return <li key={`short-description-${index}`}>{description}</li>;
           })}

--- a/src/frontend/components/views/productDetails.js
+++ b/src/frontend/components/views/productDetails.js
@@ -35,6 +35,7 @@ export function getProductDetailsData(product) {
     shortDescription: product.shortDescription,
     technicalSpecs: product.technicalSpecs,
     reviews: product.reviews,
+    url: product.url,
     relatedProducts,
   };
 }
@@ -188,6 +189,7 @@ export default function ProductDetails({ product }) {
 
   const productDetails = getProductDetailsData(product);
   const [renderRelatedProducts, setRenderRelatedProducts] = useState(false);
+  const ignoredProductKeys = ['name', 'category', 'url', 'relatedProducts', 'url'];
 
   useEffect(() => {
     productDetails.relatedProducts
@@ -199,16 +201,18 @@ export default function ProductDetails({ product }) {
       .catch((error) => console.warn('TODO: fix relatedProducts! /error:', error));
   }, []);
 
+  const getMainDetailsContent = () =>
+    Object.entries(productDetails)
+      .filter(([key]) => !ignoredProductKeys.includes(key))
+      .map(([key, value]) => <Fragment key={key}>{prepareSpecificProductDetail(key, value, true)}</Fragment>);
+
   return (
     <section>
       <p>
         [{productDetails.category}]: {productDetails.name}
       </p>
-      {Object.entries(productDetails)
-        .filter(([key]) => key !== 'relatedProducts')
-        .map(([key, value]) => (
-          <Fragment key={key}>{prepareSpecificProductDetail(key, value, true)}</Fragment>
-        ))}
+
+      {getMainDetailsContent()}
 
       {renderRelatedProducts && prepareSpecificProductDetail('relatedProducts', productDetails.relatedProducts, true)}
     </section>

--- a/src/frontend/components/views/productDetails.js
+++ b/src/frontend/components/views/productDetails.js
@@ -3,9 +3,9 @@ import { useLocation } from 'react-router-dom';
 import ProductItem from './productItem';
 import apiService from '../../features/apiService';
 
-export default function ProductDetails() {
+export default function ProductDetails({ product }) {
   // TODO: fetch product data independently when page is loaded explicitly (not navigated to from other page)
-  const { state: product } = useLocation();
+  product = product || useLocation().state;
   const translations = {
     name: 'Name',
     price: 'Price',

--- a/src/frontend/components/views/productDetails.js
+++ b/src/frontend/components/views/productDetails.js
@@ -1,69 +1,90 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, Fragment } from 'react';
 import { useLocation } from 'react-router-dom';
 import ProductItem from './productItem';
 import apiService from '../../features/apiService';
 
-export default function ProductDetails({ product }) {
-  // TODO: fetch product data independently when page is loaded explicitly (not navigated to from other page)
-  product = product || useLocation().state;
-  const translations = {
-    name: 'Name',
-    price: 'Price',
-    shortDescription: 'Short description',
-    technicalSpecs: 'Specification',
-    reviews: 'Reviews',
-    author: 'Author',
-    relatedProducts: 'Related products',
-    emptyData: 'No data!',
+const productDetailsTranslations = Object.freeze({
+  category: 'Category',
+  name: 'Name',
+  price: 'Price',
+  shortDescription: 'Short description',
+  technicalSpecs: 'Specification',
+  reviews: 'Reviews',
+  author: 'Author',
+  relatedProducts: 'Related products',
+  emptyData: 'No data!',
+});
+
+export function getProductDetailsHeaders() {
+  const detailKeys = ['category', 'name', 'price', 'shortDescription', 'technicalSpecs', 'reviews', 'relatedProducts'];
+
+  return detailKeys.reduce((detailsHeaders, key) => {
+    detailsHeaders[key] = productDetailsTranslations[key];
+
+    return detailsHeaders;
+  }, {});
+}
+
+export function getProductDetailsData(product) {
+  const relatedProducts = apiService.getProductsById(product.relatedProducts.map((item) => item.id).toString());
+
+  return {
+    category: product.category,
+    name: product.name,
+    price: product.price,
+    shortDescription: product.shortDescription,
+    technicalSpecs: product.technicalSpecs,
+    reviews: product.reviews,
+    relatedProducts,
   };
+}
 
-  console.log('[ProductDetails] product received from navigation: ', product);
+export function prepareSpecificProductDetail(detailName, detailValue, includeHeader) {
+  const getOptionalHeaderContent = (headerContent) => (includeHeader ? headerContent : null);
 
-  const [renderRelatedProducts, setRenderRelatedProducts] = useState(false);
-  const [standaloneRelatedProducts, setStandaloneRelatedProducts] = useState(null);
+  switch (detailName) {
+    case 'name':
+    case 'category': {
+      return detailValue;
+    }
 
-  useEffect(() => {
-    (async () => {
-      const relatedProducts = await apiService.getProductsById(
-        product.relatedProducts.map((item) => item.id).toString()
-      );
-      setStandaloneRelatedProducts(relatedProducts);
-      setRenderRelatedProducts(true);
-    })();
-  }, [product]);
+    case 'price': {
+      // TODO: create price component, which will handle things like promotion and will format price according to locale and/or chosen currency
+      const optionalHeaderContent = getOptionalHeaderContent(`${productDetailsTranslations.price}: `);
 
-  const getPriceContent = () => {
-    // TODO: create price component, which will handle things like promotion and will format price according to locale and/or chosen currency
-    return (
-      <p>
-        {translations.price}: ${product.price}
-      </p>
-    );
-  };
+      if (optionalHeaderContent) {
+        return (
+          <p>
+            {optionalHeaderContent}
+            {detailValue}
+          </p>
+        );
+      }
 
-  const getShortDescriptionContent = () => {
-    return (
-      <>
+      return detailValue;
+    }
+
+    case 'shortDescription': {
+      return (
         <ul className="compare-products-list__item-short-description">
-          {product.shortDescription.map((description, index) => {
+          {detailValue.map((description, index) => {
             return <li key={`short-description-${index}`}>{description}</li>;
           })}
         </ul>
-      </>
-    );
-  };
-
-  const getTechnicalSpecsContent = () => {
-    if (!Array.isArray(product.technicalSpecs)) {
-      return translations.emptyData;
+      );
     }
 
-    return (
-      // TODO: collapse it on mobile by default and expand on PC by default
-      <details>
-        <summary>{translations.technicalSpecs}:</summary>
+    case 'technicalSpecs': {
+      if (!Array.isArray(detailValue)) {
+        return productDetailsTranslations.emptyData;
+      }
+
+      const optionalHeaderContent = getOptionalHeaderContent(
+        <summary>{productDetailsTranslations.technicalSpecs}:</summary>
+      );
+      const getBodyContent = () => (
         <dl>
-          {product.technicalSpecs.map((productDetail, index) => {
+          {detailValue.map((productDetail, index) => {
             return (
               <div key={`spec-${index}`}>
                 <dt>{productDetail.heading}</dt>
@@ -72,80 +93,124 @@ export default function ProductDetails({ product }) {
             );
           })}
         </dl>
-      </details>
-    );
-  };
+      );
 
-  // TODO: move to separate component as it will likely has some additional logic (like pagination, sorting, filtering)
-  const getReviewsContent = () => {
-    if (!product.reviews.list.length) {
-      return translations.emptyData;
-    }
-
-    return (
       // TODO: collapse it on mobile by default and expand on PC by default
-      <details>
-        {/*TODO: do it in more esthetic way*/}
-        <summary>
-          {translations.reviews}: {product.reviews.summary.rating}/5 [{product.reviews.summary.reviewsAmount}]
-        </summary>
-        <ul>
-          {product.reviews.list.map((reviewEntry, index) => {
-            return (
-              <li key={`review-${index}`}>
-                <article>
-                  <header>
-                    ({reviewEntry.reviewRate}) &nbsp;
-                    <b>
-                      {translations.author}: {reviewEntry.reviewAuthor}
-                    </b>
-                    &nbsp;
-                    <time>[{reviewEntry.reviewMeta.join() /*TODO: fix empty strings in array in some cases*/}]</time>
-                  </header>
-                  <cite>{reviewEntry.content}</cite>
-                </article>
-              </li>
-            );
-          })}
-        </ul>
-      </details>
-    );
-  };
+      if (includeHeader) {
+        return (
+          <>
+            <details>
+              {optionalHeaderContent}
+              {getBodyContent()}
+            </details>
+          </>
+        );
+      }
 
-  // TODO: it probably might be used as a separate component
-  const getRelatedProductsContent = () => {
-    if (!product.relatedProducts.length || !renderRelatedProducts) {
-      return translations.emptyData;
+      return getBodyContent();
     }
 
-    return (
-      <>
-        <p>{translations.relatedProducts}</p>
-        <ul>
-          {standaloneRelatedProducts.map((relatedProduct, index) => {
-            return (
-              <li key={`related-product-${index}`}>
-                {/*TODO: ProductItem component in this case will not have full product info, so it has to somehow fetch it on it's own*/}
-                <ProductItem product={relatedProduct} />
-              </li>
-            );
-          })}
-        </ul>
-      </>
-    );
-  };
+    case 'reviews': {
+      // TODO: move to separate component as it will likely has some additional logic (like pagination, sorting, filtering)
+      if (!detailValue.list.length) {
+        return productDetailsTranslations.emptyData;
+      }
+
+      const optionalHeaderContent = getOptionalHeaderContent(`${productDetailsTranslations.reviews}: `);
+
+      return (
+        // TODO: collapse it on mobile by default and expand on PC by default
+        <details>
+          {/*TODO: do it in more aesthetic way*/}
+          <summary>
+            {optionalHeaderContent}
+            {detailValue.summary.rating}/5 [{detailValue.summary.reviewsAmount}]
+          </summary>
+          <ul>
+            {detailValue.list.map((reviewEntry, index) => {
+              return (
+                <li key={`review-${index}`}>
+                  <article>
+                    <header>
+                      ({reviewEntry.reviewRate}) &nbsp;
+                      <b>
+                        {productDetailsTranslations._author}: {reviewEntry.reviewAuthor}
+                      </b>
+                      &nbsp;
+                      <time>[{reviewEntry.reviewMeta.join() /*TODO: fix empty strings in array in some cases*/}]</time>
+                    </header>
+                    <cite>{reviewEntry.content}</cite>
+                  </article>
+                </li>
+              );
+            })}
+          </ul>
+        </details>
+      );
+    }
+
+    case 'relatedProducts': {
+      // TODO: it probably might be used as a separate component
+      if (!detailValue) {
+        return productDetailsTranslations.emptyData;
+      }
+
+      const optionalHeaderContent = getOptionalHeaderContent(<p>{productDetailsTranslations.relatedProducts}</p>);
+
+      return (
+        <>
+          {optionalHeaderContent}
+          <ul>
+            {detailValue.map((relatedProduct, index) => {
+              return (
+                <li key={`related-product-${index}`}>
+                  {/*TODO: ProductItem component in this case will not have full product info, so it has to somehow fetch it on it's own*/}
+                  <ProductItem product={relatedProduct} />
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      );
+    }
+
+    default: {
+      console.error(`detailName '${detailName}' was not matched!`);
+    }
+  }
+}
+
+export default function ProductDetails({ product }) {
+  // TODO: fetch product data independently when page is loaded explicitly (not navigated to from other page)
+  product = product || useLocation().state;
+
+  console.log('[ProductDetails] product received from navigation: ', product);
+
+  const productDetails = getProductDetailsData(product);
+  const [renderRelatedProducts, setRenderRelatedProducts] = useState(false);
+
+  useEffect(() => {
+    productDetails.relatedProducts
+      .then((relatedProducts) => {
+        if (relatedProducts.length) {
+          setRenderRelatedProducts(true);
+        }
+      })
+      .catch((error) => console.warn('TODO: fix relatedProducts! /error:', error));
+  }, []);
 
   return (
     <section>
-      Product details!
       <p>
-        [{product.category}]: {product.name}
+        [{productDetails.category}]: {productDetails.name}
       </p>
-      {getShortDescriptionContent()}
-      {getPriceContent()}
-      {getTechnicalSpecsContent()}
-      {getReviewsContent()}
-      {getRelatedProductsContent()}
+      {Object.entries(productDetails)
+        .filter(([key]) => key !== 'relatedProducts')
+        .map(([key, value]) => (
+          <Fragment key={key}>{prepareSpecificProductDetail(key, value, true)}</Fragment>
+        ))}
+
+      {renderRelatedProducts && prepareSpecificProductDetail('relatedProducts', productDetails.relatedProducts, true)}
     </section>
   );
 }

--- a/src/frontend/components/views/productItem.js
+++ b/src/frontend/components/views/productItem.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import appStore from '../../features/appStore';
-import { ComparableProductToggler } from './compareProducts';
+import CompareProduct from './compareProducts';
 
 export default function ProductItem({ product }) {
   const translations = {
@@ -45,7 +45,7 @@ export default function ProductItem({ product }) {
         {translations.detailsBtn}
       </Link>
 
-      <ComparableProductToggler product={product} />
+      <CompareProduct.Toggler product={product} />
     </div>
   );
 }

--- a/src/frontend/components/views/productItem.js
+++ b/src/frontend/components/views/productItem.js
@@ -45,7 +45,7 @@ export default function ProductItem({ product }) {
         {translations.detailsBtn}
       </Link>
 
-      <ComparableProductToggler productData={{ _id, name }} />
+      <ComparableProductToggler product={product} />
     </div>
   );
 }

--- a/src/frontend/components/views/productItem.js
+++ b/src/frontend/components/views/productItem.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import appStore from '../../features/appStore';
+import { ComparableProductToggler } from './compareProducts';
 
 export default function ProductItem({ product }) {
   const translations = {
@@ -43,6 +44,8 @@ export default function ProductItem({ product }) {
       >
         {translations.detailsBtn}
       </Link>
+
+      <ComparableProductToggler productData={{ _id, name }} />
     </div>
   );
 }

--- a/src/frontend/components/views/productItem.js
+++ b/src/frontend/components/views/productItem.js
@@ -3,16 +3,32 @@ import { Link } from 'react-router-dom';
 import appStore from '../../features/appStore';
 import CompareProduct from './compareProducts';
 
+const translations = {
+  productName: 'Name',
+  productImage: 'Image of ',
+  productUrl: 'URL',
+  price: 'Price',
+  detailsBtn: 'Check details!',
+  addToCart: 'Add to cart!',
+};
+
+export function ProductItemLink({ productData }) {
+  // TODO: maybe state should be just index or prop name of the element and target component should get it from store?
+
+  return (
+    <Link
+      to={{
+        pathname: `/shop/${productData.url}`,
+        state: productData,
+      }}
+    >
+      {translations.detailsBtn}
+    </Link>
+  );
+}
+
 export default function ProductItem({ product }) {
-  const translations = {
-    productName: 'Name',
-    productImage: 'Image of ',
-    productUrl: 'URL',
-    price: 'Price',
-    detailsBtn: 'Check details!',
-    addToCart: 'Add to cart!',
-  };
-  const { name, price, url, _id } = product;
+  const { name, price, _id } = product;
 
   const handleAddToCartClick = () => {
     appStore.updateUserCartState({ name, price, _id });
@@ -36,14 +52,7 @@ export default function ProductItem({ product }) {
 
       <button onClick={handleAddToCartClick}>{translations.addToCart}</button>
 
-      <Link
-        to={{
-          pathname: `/shop/${url}`,
-          state: product,
-        }}
-      >
-        {translations.detailsBtn}
-      </Link>
+      <ProductItemLink productData={product} />
 
       <CompareProduct.Toggler product={product} />
     </div>

--- a/src/frontend/components/views/productList.js
+++ b/src/frontend/components/views/productList.js
@@ -30,8 +30,12 @@ export default class ProductList extends React.Component {
       // TODO: set initial products per page limit based on device that runs app (f.e. mobile should have lowest limit and PC highest)
       currentProductsPerPageLimit: this.productsPerPageLimits[0],
     };
+  }
 
-    this.updateProductsList().then();
+  componentDidMount() {
+    this.updateProductsList().catch((updateProductsListError) => {
+      console.error('updateProductsListError:', updateProductsListError);
+    });
   }
 
   shouldComponentUpdate(_, nextState) {

--- a/src/frontend/components/views/productList.js
+++ b/src/frontend/components/views/productList.js
@@ -3,6 +3,7 @@ import apiService from '../../features/apiService';
 import ProductItem from './productItem';
 import Pagination from '../utils/pagination';
 import CategoriesTree from './categoriesTree';
+import { CompareProductsList } from './compareProducts';
 
 // TODO: consider refactoring class based component to a function based one (and so use mobx-react-lite instead of mobx-react)
 export default class ProductList extends React.Component {
@@ -110,6 +111,8 @@ export default class ProductList extends React.Component {
         />
 
         <button onClick={this.filterProducts.bind(this)}>{this.translations.filterProducts}</button>
+
+        <CompareProductsList />
 
         <ul className="product-list">
           {this.state.productsList.length > 0

--- a/src/frontend/components/views/productList.js
+++ b/src/frontend/components/views/productList.js
@@ -3,7 +3,7 @@ import apiService from '../../features/apiService';
 import ProductItem from './productItem';
 import Pagination from '../utils/pagination';
 import CategoriesTree from './categoriesTree';
-import { CompareProductsList } from './compareProducts';
+import CompareProducts from './compareProducts';
 
 // TODO: consider refactoring class based component to a function based one (and so use mobx-react-lite instead of mobx-react)
 export default class ProductList extends React.Component {
@@ -112,7 +112,7 @@ export default class ProductList extends React.Component {
 
         <button onClick={this.filterProducts.bind(this)}>{this.translations.filterProducts}</button>
 
-        <CompareProductsList />
+        <CompareProducts.List />
 
         {/*TODO: implement changeable layout (tiles vs list)*/}
         <ul className="product-list">

--- a/src/frontend/components/views/productList.js
+++ b/src/frontend/components/views/productList.js
@@ -114,6 +114,7 @@ export default class ProductList extends React.Component {
 
         <CompareProductsList />
 
+        {/*TODO: implement changeable layout (tiles vs list)*/}
         <ul className="product-list">
           {this.state.productsList.length > 0
             ? this.state.productsList.map((product) => {

--- a/src/frontend/features/appStore.js
+++ b/src/frontend/features/appStore.js
@@ -15,14 +15,11 @@ class AppStore {
   constructor() {
     this._userSessionState = USER_SESSION_STATES.LOGGED_OUT;
     this._userCartState = { ...USER_CART_STATE };
+    this._productComparisonState = [];
   }
 
   updateUserSessionState(userSessionState) {
     this._userSessionState = userSessionState;
-  }
-
-  getUserSessionState() {
-    return this._userSessionState;
   }
 
   updateUserCartState(userCartState) {
@@ -54,6 +51,23 @@ class AppStore {
     }
   }
 
+  updateProductComparisonState({ add, remove }) {
+    console.log('updateProductComparisonState() /add:', add, ' /remove:', remove);
+
+    if (add) {
+      this._productComparisonState.push(add);
+    } else if (typeof remove.index === 'number') {
+      this._productComparisonState.splice(remove.index, 1);
+    } else if (remove._id) {
+      const removeIndex = this._productComparisonState.findIndex((product) => product._id === remove._id);
+      this._productComparisonState.splice(removeIndex, 1);
+    }
+  }
+
+  clearProductComparisonState() {
+    this._productComparisonState.length = 0;
+  }
+
   get userCartState() {
     return this._userCartState;
   }
@@ -69,6 +83,14 @@ class AppStore {
   get userCartProductsCount() {
     return this._userCartState.totalCount;
   }
+
+  get userSessionState() {
+    return this._userSessionState;
+  }
+
+  get productComparisonState() {
+    return this._productComparisonState;
+  }
 }
 
 decorate(AppStore, {
@@ -78,6 +100,10 @@ decorate(AppStore, {
   _userCartState: observable,
   updateUserCartState: action,
   clearUserCartState: action,
+
+  _productComparisonState: observable,
+  updateProductComparisonState: action,
+  clearProductComparisonState: action,
 });
 
 const appStore = new AppStore();

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -10,6 +10,8 @@
     <link rel="shortcut icon" type="image/png" href="/src/frontend/assets/icons/icons8-engine-48.png" />
   </head>
   <body>
+    <!-- TODO: add <noscript> tag with multi-lang information -->
+
     <div id="app" class="app-root"></div>
   </body>
 </html>

--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -1,5 +1,7 @@
 import './assets/styles/main.scss';
 
+import 'react-hot-loader';
+import { hot } from 'react-hot-loader/root';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter as Router } from 'react-router-dom';
@@ -18,4 +20,4 @@ const App = (
   </>
 );
 
-ReactDOM.render(App, document.querySelector('#app'));
+hot(ReactDOM.render(App, document.querySelector('#app')));

--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -1,22 +1,6 @@
-import 'react-hot-loader';
-import { hot } from 'react-hot-loader/root';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { BrowserRouter as Router } from 'react-router-dom';
-
+import HotApp from './app';
 import './assets/styles/main.scss';
-import Header from './components/views/header';
-import Main from './components/views/main';
-import Footer from './components/views/footer';
 
-const App = (
-  <>
-    <Router>
-      <Header />
-      <Main />
-      <Footer />
-    </Router>
-  </>
-);
-
-hot(ReactDOM.render(App, document.querySelector('#app')));
+ReactDOM.render(<HotApp />, document.querySelector('#app'));

--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -1,11 +1,10 @@
-import './assets/styles/main.scss';
-
 import 'react-hot-loader';
 import { hot } from 'react-hot-loader/root';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter as Router } from 'react-router-dom';
 
+import './assets/styles/main.scss';
 import Header from './components/views/header';
 import Main from './components/views/main';
 import Footer from './components/views/footer';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = (env) => {
 
   return {
     mode: env,
-    entry: './src/frontend/index.js',
+    entry: ['react-hot-loader/patch','./src/frontend/index.js'],
     output: {
       filename: 'index.js',
       path: resolve(__dirname, './dist/src/frontend'),
@@ -53,6 +53,8 @@ module.exports = (env) => {
       historyApiFallback: true,
       before: middleware,
       port: process.env.PORT,
+      hotOnly: true,
+      liveReload: false,
     }
   };
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,12 @@ module.exports = (env) => {
         {
           test: /\.scss$/,
           use: [
-            MiniCssExtractPlugin.loader,
+            {
+              loader: MiniCssExtractPlugin.loader,
+              options: {
+                hmr: env === 'development',
+              },
+            },
             'css-loader',
             'sass-loader'
           ]


### PR DESCRIPTION
Partially related to #2 (compare feature).

Changes contain:
- added [`react-hot-loader`](https://github.com/gaearon/react-hot-loader), which handles JS and SCSS code changes
- checkbox at each product on `/shop` page list, which adds or removes the product from compare list widget
- list widget on `/shop` page, which gathers products chosen by user to compare them on separate view
- `/compare` page with table presenting compared products
- UI slider feature, which shows up when viewport is narrow enough to make contained content overflow the slider parent. Slider moves accordingly to the left or right via buttons making it possible to see whole of it's cropped content