### PR TITLE
Added UI for modifying product feature

### DIFF
--- a/src/database/database-index.ts
+++ b/src/database/database-index.ts
@@ -85,11 +85,11 @@ async function getFromDB(
 }
 
 // TODO: consider making this function either specific to update case or generic dependent on params
-function updateOneModelInDB(
+async function updateOneModelInDB(
   itemQuery: any,
   updateData: any,
   modelType: TModelType
-): ReturnType<typeof Model.findOneAndUpdate> | null {
+): Promise<ReturnType<typeof Model.findOneAndUpdate> | null> {
   const Model = getModel(modelType);
 
   // TODO: improve querying via various ways
@@ -113,6 +113,7 @@ function updateOneModelInDB(
       break;
     }
     default: {
+      logger.error(`No operator for "${updateData.action}" action to update was matched!`);
       return null;
     }
   }
@@ -122,7 +123,7 @@ function updateOneModelInDB(
     [operator]: updateData.data,
   };
 
-  return Model.findOneAndUpdate(itemQuery, updateDataQueries, { new: true });
+  return await Model.findOneAndUpdate(itemQuery, updateDataQueries, { new: true });
 }
 
 export { saveToDB, getFromDB, updateOneModelInDB, queryBuilder, ObjectId };

--- a/src/frontend/components/pages/newProduct.js
+++ b/src/frontend/components/pages/newProduct.js
@@ -42,7 +42,7 @@ const FIELD_NAME_PREFIXES = Object.freeze({
   TECHNICAL_SPECS: `technicalSpecs${SPEC_NAMES_SEPARATORS.LEVEL}`,
 });
 
-function BaseInfo({ data: { initialData }, methods: { handleChange, handleBlur } }) {
+function BaseInfo({ data: { initialData = {} }, methods: { handleChange, handleBlur } }) {
   return (
     <fieldset>
       <legend>{translations.baseInformation}</legend>
@@ -168,8 +168,12 @@ ShortDescription.InputComponent = function InputComponent(props) {
   );
 };
 
-function CategorySelector({ methods: { setProductCurrentSpecs, getSpecsForSelectedCategory } }) {
+function CategorySelector({
+  data: { initialData = {} },
+  methods: { setProductCurrentSpecs, getSpecsForSelectedCategory },
+}) {
   const handleCategorySelect = (selectedCategoryName) => {
+    console.log('(CategorySelector) selectedCategoryName:', selectedCategoryName);
     setProductCurrentSpecs(getSpecsForSelectedCategory(selectedCategoryName));
   };
 
@@ -181,7 +185,8 @@ function CategorySelector({ methods: { setProductCurrentSpecs, getSpecsForSelect
         name="category"
         required
         component={CategoriesTreeFormField}
-        onCategorySelect={(selectedCategory) => handleCategorySelect(selectedCategory)}
+        onCategorySelect={handleCategorySelect}
+        preSelectedCategory={initialData.category}
       />
       <ErrorMessage name="category" component={FormFieldError} />
     </fieldset>
@@ -307,7 +312,7 @@ function RelatedProductsNames({ data: { initialData = {} }, field: formikField, 
   );
 }
 
-const ProductForm = ({ initialData }) => {
+const ProductForm = ({ initialData = {} }) => {
   const [productCurrentSpecs, setProductCurrentSpecs] = useState([]);
   const productSpecsMap = useRef({
     specs: null,
@@ -332,6 +337,8 @@ const ProductForm = ({ initialData }) => {
       const productSpecifications = await productSpecsService
         .getProductsSpecifications()
         .then(productSpecsService.structureProductsSpecifications);
+
+      console.log('[awaited!]');
 
       productSpecsMap.current.categoryToSpecs = productSpecifications.categoryToSpecs;
       productSpecsMap.current.specs = productSpecifications.specs.map((specObj) => ({
@@ -510,7 +517,12 @@ const ProductForm = ({ initialData }) => {
               data={{ initialData: formikRestProps.values }}
               component={ShortDescription}
             />
-            <CategorySelector methods={{ setProductCurrentSpecs, getSpecsForSelectedCategory }} />
+            {Object.values(productSpecsMap.current).filter(Boolean).length && (
+              <CategorySelector
+                data={{ initialData: formikRestProps.values }}
+                methods={{ setProductCurrentSpecs, getSpecsForSelectedCategory }}
+              />
+            )}
             <TechnicalSpecs data={{ productCurrentSpecs }} methods={{ handleChange: formikRestProps.handleChange }} />
             <Field
               name="relatedProductsNames"

--- a/src/frontend/components/pages/newProduct.js
+++ b/src/frontend/components/pages/newProduct.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useRef, createRef, useCallback, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Formik, Field, ErrorMessage } from 'formik';
 import apiService from '../../features/apiService';
 import productSpecsService from '../../features/productSpecsService';
@@ -612,7 +613,8 @@ const NewProduct = () => {
 
   return <ProductForm doSubmit={doSubmit} />;
 };
-const ModifyProduct = ({ productName }) => {
+const ModifyProduct = () => {
+  const productName = useLocation().state;
   const [productData, setProductData] = useState(null);
   const [modificationError, setModificationError] = useState(false);
   const getChangedFields = useCallback(

--- a/src/frontend/components/utils/flexibleList.js
+++ b/src/frontend/components/utils/flexibleList.js
@@ -16,13 +16,15 @@ const flexibleListStates = Object.freeze({
   EDITING_INDEX: 'EDITING_INDEX',
 });
 
-function FlexibleList({ newItemComponent, editItemComponent, emitUpdatedItemsList }) {
+function FlexibleList({ initialListItems = [], newItemComponent, editItemComponent, emitUpdatedItemsList }) {
   if (!newItemComponent || !editItemComponent) {
     throw ReferenceError('newItemComponent, editItemComponent and renderInput must be provided!');
   }
 
   const EMPTY_LIST_ITEM = '';
-  const [listItems, setListItems] = useState([EMPTY_LIST_ITEM]);
+  const [listItems, setListItems] = useState(() =>
+    initialListItems.length ? initialListItems.concat(EMPTY_LIST_ITEM) : [EMPTY_LIST_ITEM]
+  );
   const [state, dispatch] = useReducer(flexibleListReducer, {
     [flexibleListStates.ADD_BTN_VISIBILITY]: true,
     [flexibleListStates.EDITING_INDEX]: -1,

--- a/src/frontend/components/views/categoriesTree.js
+++ b/src/frontend/components/views/categoriesTree.js
@@ -1,11 +1,31 @@
-import React, { useState, useEffect, createRef, useRef } from 'react';
+import React, { useState, useEffect, useCallback, createRef, useRef } from 'react';
 import apiService from '../../features/apiService';
 import TreeMenu from 'react-simple-tree-menu';
 
-function CategoriesTree({ onCategorySelect, isMultiselect, formField }) {
+const CATEGORIES_SEPARATOR = '|';
+
+function CategoriesTree({ preSelectedCategory = '', onCategorySelect, isMultiselect, formField }) {
+  const parsedPreSelectedCategory = preSelectedCategory.split(CATEGORIES_SEPARATOR);
   const [categoriesMap, setCategoriesMap] = useState(null);
+  const [autoSelectedCategory, setAutoSelectedCategory] = useState(false);
   const categoriesTreeRef = createRef();
   const activeTreeNodes = useRef(new Map());
+  const findNodeToPreSelect = useCallback(function _findNodeToPreSelect(output, processedPreSelectedCategory, node) {
+    output.activeKey += node.key;
+
+    if (Array.isArray(node.nodes)) {
+      output.openedNodes.push(node.key);
+      processedPreSelectedCategory.shift();
+
+      if (processedPreSelectedCategory.length) {
+        const subCategoryName = processedPreSelectedCategory.shift();
+        const subNode = node.nodes.find((subNodeItem) => subNodeItem.label === subCategoryName);
+
+        output.activeKey += '/';
+        _findNodeToPreSelect(output, processedPreSelectedCategory, subNode);
+      }
+    }
+  }, []);
 
   useEffect(() => {
     (async () => {
@@ -15,26 +35,48 @@ function CategoriesTree({ onCategorySelect, isMultiselect, formField }) {
     })();
   }, []);
 
-  const getCategoriesTree = () => {
-    if (categoriesMap) {
-      const treeData = categoriesMap.map(getCategoriesTree.recursiveMapper);
+  useEffect(() => {
+    if (autoSelectedCategory) {
+      onCategorySelect(preSelectedCategory);
+    }
+  }, [autoSelectedCategory]);
 
-      return (
-        <TreeMenu
-          data={treeData}
-          onClickItem={(clickedItem) =>
-            toggleActiveTreeNode(
-              clickedItem.level,
-              clickedItem.index,
-              toggleActiveTreeNode.matchParentKey(treeData, clickedItem),
-              clickedItem.label
-            )
-          }
-        />
-      );
+  const getCategoriesTree = () => {
+    if (!categoriesMap) {
+      return;
     }
 
-    return null;
+    const treeData = categoriesMap.map(getCategoriesTree.recursiveMapper);
+    const initials = treeData.reduce(
+      (output, node) => {
+        if (node.label === parsedPreSelectedCategory[0]) {
+          findNodeToPreSelect(output, [...parsedPreSelectedCategory], node);
+        }
+
+        return output;
+      },
+      { activeKey: '', openedNodes: [] }
+    );
+
+    if (initials.activeKey && !autoSelectedCategory) {
+      setAutoSelectedCategory(true);
+    }
+
+    return (
+      <TreeMenu
+        data={treeData}
+        onClickItem={(clickedItem) =>
+          toggleActiveTreeNode(
+            clickedItem.level,
+            clickedItem.index,
+            toggleActiveTreeNode.matchParentKey(treeData, clickedItem),
+            clickedItem.label
+          )
+        }
+        initialActiveKey={initials.activeKey}
+        initialOpenNodes={initials.openedNodes}
+      />
+    );
   };
   getCategoriesTree.levels = ['first', 'second', 'third', 'fourth'];
   // TODO: handle selecting tree node wrapper (as "Parts") - it should auto-select all it's descendants and not consider node itself being selected
@@ -101,7 +143,7 @@ function CategoriesTree({ onCategorySelect, isMultiselect, formField }) {
   };
   toggleActiveTreeNode.matchParentKey = (treeData, clickedItem) => {
     const matchedParent = treeData.find((node) => clickedItem.parent && clickedItem.parent === node.key);
-    return matchedParent ? `${matchedParent.label}|` : '';
+    return matchedParent ? `${matchedParent.label}${CATEGORIES_SEPARATOR}` : '';
   };
 
   return (

--- a/src/frontend/components/views/main.js
+++ b/src/frontend/components/views/main.js
@@ -3,7 +3,7 @@ import { Route, Switch } from 'react-router-dom';
 
 import Home from '../pages/home';
 import Shop from '../pages/shop';
-import NewProduct from '../pages/newProduct';
+import { NewProduct, ModifyProduct } from '../pages/newProduct';
 import LogIn from '../pages/logIn';
 import Account from '../pages/account';
 import Compare from '../pages/compare';
@@ -24,6 +24,9 @@ export default function Main() {
         </Route>
         <Route path="/add-new-product">
           <NewProduct />
+        </Route>
+        <Route path="/modify-product">
+          <ModifyProduct productName="testowy" />
         </Route>
         <Route path="/log-in">
           <LogIn />

--- a/src/frontend/components/views/main.js
+++ b/src/frontend/components/views/main.js
@@ -25,9 +25,7 @@ export default function Main() {
         <Route path="/add-new-product">
           <NewProduct />
         </Route>
-        <Route path="/modify-product">
-          <ModifyProduct productName="testowy ext" />
-        </Route>
+        <Route path="/modify-product" component={ModifyProduct} />
         <Route path="/log-in">
           <LogIn />
         </Route>

--- a/src/frontend/components/views/main.js
+++ b/src/frontend/components/views/main.js
@@ -26,7 +26,7 @@ export default function Main() {
           <NewProduct />
         </Route>
         <Route path="/modify-product">
-          <ModifyProduct productName="testowy" />
+          <ModifyProduct productName="testowy ext" />
         </Route>
         <Route path="/log-in">
           <LogIn />

--- a/src/frontend/components/views/nav.js
+++ b/src/frontend/components/views/nav.js
@@ -14,6 +14,7 @@ export default observer(function Nav() {
     start: 'Start',
     shop: 'Sklep',
     addNewProduct: 'Dodaj nowy produkt',
+    modifyProduct: 'Modyfikuj produkt',
     logIn: 'Zaloguj się',
     logOut: 'Wyloguj się',
     account: 'Moje konto',
@@ -30,6 +31,9 @@ export default observer(function Nav() {
         </li>
         <li>
           <Link to="/add-new-product">{translations.addNewProduct}</Link>
+        </li>
+        <li>
+          <Link to="/modify-product">{translations.modifyProduct}</Link>
         </li>
         <li>
           {appStore.userSessionState === USER_SESSION_STATES.LOGGED_OUT ? (

--- a/src/frontend/components/views/productDetails.js
+++ b/src/frontend/components/views/productDetails.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, Fragment } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useHistory } from 'react-router-dom';
 import ProductItem from './productItem';
 import apiService from '../../features/apiService';
 
@@ -12,6 +12,7 @@ const productDetailsTranslations = Object.freeze({
   reviews: 'Reviews',
   author: 'Author',
   relatedProducts: 'Related products',
+  editProduct: 'Edit',
   emptyData: 'No data!',
 });
 
@@ -190,6 +191,7 @@ export function prepareSpecificProductDetail(detailName, detailValue, includeHea
 export default function ProductDetails({ product }) {
   // TODO: fetch product data independently when page is loaded explicitly (not navigated to from other page)
   product = product || useLocation().state;
+  const history = useHistory();
 
   console.log('[ProductDetails] product received from navigation: ', product);
 
@@ -214,10 +216,15 @@ export default function ProductDetails({ product }) {
       .filter(([key]) => !ignoredProductKeys.includes(key))
       .map(([key, value]) => <Fragment key={key}>{prepareSpecificProductDetail(key, value, true)}</Fragment>);
 
+  const navigateToProductModify = () => {
+    history.push('/modify-product', productDetails.name);
+  };
+
   return (
     <section>
       <p>
         [{productDetails.category}]: {productDetails.name}
+        <button onClick={navigateToProductModify}>{productDetailsTranslations.editProduct}</button>
       </p>
 
       {getMainDetailsContent()}

--- a/src/middleware/routes/api-products.ts
+++ b/src/middleware/routes/api-products.ts
@@ -141,7 +141,7 @@ async function addProduct(req: Request, res: Response): Promise<void> {
   }
 }
 
-function modifyProduct(req: Request & { userPermissions: any }, res: Response): void {
+async function modifyProduct(req: Request & { userPermissions: any }, res: Response): Promise<void> {
   try {
     logger.log('[products PATCH] req.body', req.body);
 
@@ -150,10 +150,13 @@ function modifyProduct(req: Request & { userPermissions: any }, res: Response): 
     }
 
     // TODO: prepare to be used with various product properties
-    const modifiedProduct = updateOneModelInDB(req.body.productId, req.body.modifications, 'Product');
+    const modifiedProduct = await updateOneModelInDB(
+      req.body.productId || { name: req.body.name },
+      req.body.modifications,
+      'Product'
+    );
 
-    logger.log('Product modified', modifiedProduct);
-    res.status(201).json({ payload: modifiedProduct });
+    res.status(200).json({ payload: modifiedProduct });
   } catch (exception) {
     logger.error('Modifying product exception:', exception);
 

--- a/test/database/database-index.spec.ts
+++ b/test/database/database-index.spec.ts
@@ -176,8 +176,8 @@ describe('#database-index', () => {
     });
 
     it('should return null if updateData.action prop was not matched', () => {
-      expect(updateOneModelInDB({}, {}, MODEL_TYPE)).toBeNull();
-      expect(updateOneModelInDB({}, { action: 'add' }, MODEL_TYPE)).toBeNull();
+      expect(updateOneModelInDB({}, {}, MODEL_TYPE)).resolves.toBeNull();
+      expect(updateOneModelInDB({}, { action: 'add' }, MODEL_TYPE)).resolves.toBeNull();
     });
 
     it('should return value or null depend on Model.findOneAndUpdate(..) result', () => {
@@ -187,11 +187,11 @@ describe('#database-index', () => {
 
       const updateData = { action: 'addUnique' };
 
-      expect(updateOneModelInDB({}, updateData, MODEL_TYPE)).toStrictEqual(
+      expect(updateOneModelInDB({}, updateData, MODEL_TYPE)).resolves.toStrictEqual(
         // @ts-ignore
         new ModelModuleMock._ModelClassMock.findOneAndUpdate._clazz()
       );
-      expect(updateOneModelInDB({}, updateData, MODEL_TYPE)).toBeNull();
+      expect(updateOneModelInDB({}, updateData, MODEL_TYPE)).resolves.toBeNull();
     });
   });
 });

--- a/test/middleware/routes/api-products.spec.ts
+++ b/test/middleware/routes/api-products.spec.ts
@@ -278,14 +278,14 @@ describe('#api-products', () => {
         );
       });
 
-      it('should call res.status(..).json(..) with correct params', () => {
+      it('should call res.status(..).json(..) with correct params', async () => {
         const resMock = getResMock();
 
-        apiProductsRouter._modifyProduct(getReqMock(), resMock);
+        await apiProductsRouter._modifyProduct(getReqMock(), resMock);
 
         updateOneModelInDBMock.mockImplementationOnce(updateOneModelInDBMock._succeededCall);
 
-        expect(resMock.status).toHaveBeenCalledWith(201);
+        expect(resMock.status).toHaveBeenCalledWith(200);
         expect(resMock._jsonMethod).toHaveBeenCalledWith({ payload: updateOneModelInDBMock() });
       });
     });


### PR DESCRIPTION
Extends #18.

- add `ModifyProduct` component, which uses `ProductForm` created from `NewProduct` component, which now has only lifted up essentials
- apply presetting values to product form fields fetched from API to let user to modify them
- add basic validation for unchanged fields
- add "edit" button in `ProductDetails` component to let navigating to product modification view
- extend `ApiService` to integrate product data patching with backend
- adjust unit tests