### PR TITLE
Implemented reset account password feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16780,11 +16780,6 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-    },
     "v8-compile-cache": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "mongoose-type-email": "^1.1.2",
     "nodemailer": "^6.7.0",
     "react-paginate": "^7.0.0",
-    "react-simple-tree-menu": "^1.1.18",
-    "uuid": "^8.3.2"
+    "react-simple-tree-menu": "^1.1.18"
   }
 }

--- a/src/database/models/_user.ts
+++ b/src/database/models/_user.ts
@@ -1,4 +1,4 @@
-import type { Document } from 'mongoose';
+import type { Document, Model } from 'mongoose';
 import { model, Schema } from 'mongoose';
 import { randomBytes } from 'crypto';
 import { getToken, comparePasswords } from '../../middleware/features/auth';
@@ -155,7 +155,11 @@ userSchema.statics.findByCredentials = async (userModel: any, nick: string, pass
   return user;
 };
 
-const UserModel = model<IUser>('User', userSchema);
+const UserModel = model<IUser, IUserStatics>('User', userSchema);
+
+interface IUserStatics extends Model<IUser> {
+  validatePassword(password: any): string;
+}
 
 export interface IUser extends Document {
   login: string;
@@ -174,9 +178,6 @@ export interface IUser extends Document {
   setSingleToken(tokenName: TSingleTokensKeys): Promise<IUser>;
   deleteSingleToken(tokenName: TSingleTokensKeys): Promise<IUser>;
   confirmUser(): Promise<IUser>;
-
-  // TODO: [TS] fix TS error related to non-static method
-  //static validatePassword(password: any): string;
 }
 
 export default UserModel;

--- a/src/database/models/_user.ts
+++ b/src/database/models/_user.ts
@@ -1,7 +1,6 @@
 import type { Document } from 'mongoose';
 import { model, Schema } from 'mongoose';
-// TODO: [refactor] swap it for crypto.randomBytes(..)
-import { v4 as uuidv4 } from 'uuid';
+import { randomBytes } from 'crypto';
 import { getToken, comparePasswords } from '../../middleware/features/auth';
 
 require('mongoose-type-email');
@@ -105,7 +104,7 @@ userSchema.methods.matchPassword = function (password: string): Promise<boolean>
 };
 
 userSchema.methods.setSingleToken = function (tokenName: TSingleTokensKeys): Promise<IUser> {
-  this.tokens[tokenName] = uuidv4();
+  this.tokens[tokenName] = randomBytes(256).toString('base64');
 
   setTimeout(() => this.deleteSingleToken(tokenName), SINGLE_TOKEN_EXPIRE_TIME_MS);
 

--- a/src/frontend/components/pages/adHocUserUpdate.js
+++ b/src/frontend/components/pages/adHocUserUpdate.js
@@ -1,0 +1,146 @@
+import React, { useState, useEffect } from 'react';
+import { /* useHistory, */ useLocation } from 'react-router-dom';
+import { Formik, Field } from 'formik';
+import FormFieldError from '../utils/formFieldError';
+import apiService from '../../features/apiService';
+
+const translations = Object.freeze({
+  resetPasswordHeader: 'Reset password',
+  resettingEmailField: 'Email associated with user account',
+  submitReset: 'Reset',
+  setNewPasswordHeader: 'Set new password',
+  newPasswordField: 'Password',
+  repeatNewPasswordField: 'Repeat password',
+  bothPasswordFieldsMustBeEqual: 'Both password fields must be equal!',
+  submitNewPassword: 'Update password',
+});
+
+function ResetPassword() {
+  console.log('(ResetPassword)');
+
+  const [formInitials] = useState({
+    email: '',
+  });
+
+  const onSubmitHandler = (values) => {
+    apiService.resetPassword(values.email).then((res) => console.log('reset password res:', res));
+  };
+
+  return (
+    <section>
+      <Formik onSubmit={onSubmitHandler} initialValues={formInitials}>
+        {({ handleSubmit }) => (
+          <form onSubmit={handleSubmit}>
+            <fieldset>
+              <legend>
+                <h2>{translations.resetPasswordHeader}</h2>
+              </legend>
+
+              <div>
+                <label htmlFor="resettingEmail">{translations.resettingEmailField}</label>
+                <Field name="email" id="resettingEmail" type="email" required />
+              </div>
+
+              <button>{translations.submitReset}</button>
+            </fieldset>
+          </form>
+        )}
+      </Formik>
+    </section>
+  );
+}
+
+function SetNewPassword() {
+  const [token, setToken] = useState('');
+  const [formInitials] = useState({
+    newPassword: '',
+    repeatedNewPassword: '',
+  });
+  //   const history = useHistory();
+  const { search: searchParam } = useLocation();
+
+  useEffect(() => {
+    setToken(new URLSearchParams(searchParam).get('token'));
+  }, []);
+
+  const formValidator = (values) => {
+    const errors = {};
+
+    if (values.newPassword && values.repeatedNewPassword && values.newPassword !== values.repeatedNewPassword) {
+      errors.newPassword = translations.bothPasswordFieldsMustBeEqual;
+      errors.repeatedNewPassword = translations.bothPasswordFieldsMustBeEqual;
+    }
+
+    return errors;
+  };
+
+  const onSubmitHandler = (values) => {
+    if (token) {
+      apiService
+        .updateUserAdHoc(
+          {
+            name: 'password',
+            value: values.newPassword,
+          },
+          { name: 'resetPassword', value: token }
+        )
+        .then((res) => {
+          console.log('(resetPassword) res?', res);
+
+          // if ('isPasswordReset' in res) {
+          //   setRegConfirmStatus(res.isPasswordReset ? RESET_CONFIRM_STATUS.SUCCEEDED : RESET_CONFIRM_STATUS.FAILED);
+          // }
+        });
+    } /*  else {
+        setRegConfirmStatus(REG_CONFIRM_STATUS.FAILED);
+      } */
+  };
+
+  //   const logIn = () => history.push('/log-in');
+
+  return (
+    <section>
+      <Formik onSubmit={onSubmitHandler} validateOnChange={false} validate={formValidator} initialValues={formInitials}>
+        {({ handleSubmit, ...formikRestProps }) => (
+          <form onSubmit={handleSubmit}>
+            <fieldset>
+              <legend>
+                <h2>{translations.setNewPasswordHeader}</h2>
+              </legend>
+
+              {/* TODO: [DUP] move password related elements to generic component to avoid redundancy */}
+              <div>
+                <label htmlFor="newPassword">{translations.passwordField}</label>
+                {/* TODO: [UX] add feature to temporary preview (unmask) the password field */}
+                <Field name="newPassword" id="newPassword" type="password" minLength="8" maxLength="20" required />
+
+                {formikRestProps.errors.newPassword && (
+                  <FormFieldError>{formikRestProps.errors.newPassword}</FormFieldError>
+                )}
+              </div>
+              <div>
+                <label htmlFor="repeatedNewPassword">{translations.repeatedPasswordField}</label>
+                <Field
+                  name="repeatedNewPassword"
+                  id="repeatedNewPassword"
+                  type="password"
+                  minLength="8"
+                  maxLength="20"
+                  required
+                />
+
+                {formikRestProps.errors.repeatedNewPassword && (
+                  <FormFieldError>{formikRestProps.errors.repeatedNewPassword}</FormFieldError>
+                )}
+              </div>
+
+              <button>{translations.submitNewPassword}</button>
+            </fieldset>
+          </form>
+        )}
+      </Formik>
+    </section>
+  );
+}
+
+export { ResetPassword, SetNewPassword };

--- a/src/frontend/components/pages/logIn.js
+++ b/src/frontend/components/pages/logIn.js
@@ -74,6 +74,7 @@ export default function LogIn() {
       </div>
 
       {/* TODO: [UX] if User account is not confirmed, show an info with hint to re-send activation email */}
+      {/* TODO: [UX] if User credentials are invalid, show regarding info instead of redirecting to /account  */}
 
       {loggedInUserData && (
         <Redirect

--- a/src/frontend/components/pages/logIn.js
+++ b/src/frontend/components/pages/logIn.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Redirect } from 'react-router-dom';
+import { Redirect, Link } from 'react-router-dom';
 import appStore, { USER_SESSION_STATES } from '../../features/appStore';
 import apiService from '../../features/apiService';
 
@@ -8,6 +8,8 @@ const translations = Object.freeze({
   logInField: 'Login',
   passwordField: 'Password',
   submitLogIn: 'Login!',
+  resetPasswordHint: `Don't remember password?`,
+  resetPasswordLink: 'Reset it!',
 });
 
 export default function LogIn() {
@@ -65,6 +67,14 @@ export default function LogIn() {
           <button type="submit">{translations.submitLogIn}</button>
         </fieldset>
       </form>
+
+      <div>
+        <p>{translations.resetPasswordHint}</p>
+        <Link to={'/reset-password'}>{translations.resetPasswordLink}</Link>
+      </div>
+
+      {/* TODO: [UX] if User account is not confirmed, show an info with hint to re-send activation email */}
+
       {loggedInUserData && (
         <Redirect
           to={{

--- a/src/frontend/components/pages/recoverAccount.js
+++ b/src/frontend/components/pages/recoverAccount.js
@@ -11,7 +11,7 @@ const translations = Object.freeze({
   submitReset: 'Reset',
   setNewPasswordHeader: 'Set new password',
   newPasswordField: 'Password',
-  repeatNewPasswordField: 'Repeat password',
+  repeatedNewPasswordField: 'Repeat password',
   bothPasswordFieldsMustBeEqual: 'Both password fields must be equal!',
   submitNewPassword: 'Update password',
   resetPasswordSuccessMsg: `
@@ -163,7 +163,7 @@ function SetNewPassword() {
 
               {/* TODO: [DUP] move password related elements to generic component to avoid redundancy */}
               <div>
-                <label htmlFor="newPassword">{translations.passwordField}</label>
+                <label htmlFor="newPassword">{translations.newPasswordField}</label>
                 {/* TODO: [UX] add feature to temporary preview (unmask) the password field */}
                 <Field name="newPassword" id="newPassword" type="password" minLength="8" maxLength="20" required />
 
@@ -172,7 +172,7 @@ function SetNewPassword() {
                 )}
               </div>
               <div>
-                <label htmlFor="repeatedNewPassword">{translations.repeatedPasswordField}</label>
+                <label htmlFor="repeatedNewPassword">{translations.repeatedNewPasswordField}</label>
                 <Field
                   name="repeatedNewPassword"
                   id="repeatedNewPassword"

--- a/src/frontend/components/pages/register.js
+++ b/src/frontend/components/pages/register.js
@@ -16,13 +16,13 @@ const translations = Object.freeze({
   clientType: 'Client',
   retailerType: 'Retailer',
   bothPasswordFieldsMustBeEqual: 'Both password fields must be equal!',
-  emailSuccessMsg: `
+  registrationSuccessMsg: `
     Account registered! 
     You need to confirm your account via the link we sent you on email, 
     before you'll be able to log in.
   `.trim(),
-  emailFailureMsg: 'Failed to register new account :(',
-  emailSuccessAltMsg: "Email hasn't arrived yet? Click the button and we will re-send the email again.",
+  registrationFailureMsg: 'Failed to register new account :(',
+  registrationSuccessAltMsg: "Email hasn't arrived yet? Click the button and we will re-send the email again.",
   popupReSendEmail: 'Re-send email',
   popupGoToLogin: 'Go to login',
 });
@@ -60,8 +60,8 @@ export default function Register() {
       if (res.msg) {
         setPopupData({
           type: POPUP_TYPES.SUCCESS,
-          message: translations.emailSuccessMsg,
-          altMessage: translations.emailSuccessAltMsg,
+          message: translations.registrationSuccessMsg,
+          altMessage: translations.registrationSuccessAltMsg,
           buttons: [
             {
               onClick: () => history.push('/log-in'),
@@ -78,7 +78,7 @@ export default function Register() {
       } else {
         setPopupData({
           type: POPUP_TYPES.FAILURE,
-          message: translations.emailFailureMsg,
+          message: translations.registrationFailureMsg,
           buttons: [getClosePopupBtn(setPopupData)],
         });
       }

--- a/src/frontend/components/views/main.js
+++ b/src/frontend/components/views/main.js
@@ -10,7 +10,7 @@ import Account from '../pages/account';
 import Compare from '../pages/compare';
 import Order from '../pages/order';
 import ConfirmRegistration from '../pages/confirmRegistration';
-import * as AdHocUserUpdate from '../pages/adHocUserUpdate';
+import * as RecoverAccount from '../pages/recoverAccount';
 
 export default function Main() {
   return (
@@ -41,10 +41,10 @@ export default function Main() {
           <LogIn />
         </Route>
         <Route path="/reset-password">
-          <AdHocUserUpdate.ResetPassword />
+          <RecoverAccount.ResetPassword />
         </Route>
         <Route path="/set-new-password">
-          <AdHocUserUpdate.SetNewPassword />
+          <RecoverAccount.SetNewPassword />
         </Route>
         <Route path="/account">
           <Account />

--- a/src/frontend/components/views/main.js
+++ b/src/frontend/components/views/main.js
@@ -10,6 +10,7 @@ import Account from '../pages/account';
 import Compare from '../pages/compare';
 import Order from '../pages/order';
 import ConfirmRegistration from '../pages/confirmRegistration';
+import * as AdHocUserUpdate from '../pages/adHocUserUpdate';
 
 export default function Main() {
   return (
@@ -38,6 +39,12 @@ export default function Main() {
         </Route>
         <Route path="/log-in">
           <LogIn />
+        </Route>
+        <Route path="/reset-password">
+          <AdHocUserUpdate.ResetPassword />
+        </Route>
+        <Route path="/set-new-password">
+          <AdHocUserUpdate.SetNewPassword />
         </Route>
         <Route path="/account">
           <Account />

--- a/src/frontend/features/apiService.js
+++ b/src/frontend/features/apiService.js
@@ -225,6 +225,10 @@ const apiService = new (class ApiService extends Ajax {
     return this.postRequest(`${this.USERS_URL}/login`, credentials);
   }
 
+  resetPassword(email) {
+    return this.postRequest(`${this.USERS_URL}/reset-password`, { email });
+  }
+
   logoutUser() {
     return this.postRequest(`${this.USERS_URL}/logout`, null, true);
   }
@@ -239,6 +243,10 @@ const apiService = new (class ApiService extends Ajax {
 
   resendConfirmRegistration(email) {
     return this.postRequest(`${this.USERS_URL}/resend-confirm-registration`, { email });
+  }
+
+  updateUserAdHoc(userModifications, tokenObj) {
+    return this.patchRequest(`${this.USERS_URL}/update-adhoc`, { userModifications, tokenObj });
   }
 })();
 

--- a/src/frontend/features/apiService.js
+++ b/src/frontend/features/apiService.js
@@ -229,6 +229,10 @@ const apiService = new (class ApiService extends Ajax {
     return this.postRequest(`${this.USERS_URL}/reset-password`, { email });
   }
 
+  resendResetPassword(email) {
+    return this.postRequest(`${this.USERS_URL}/resend-reset-password`, { email });
+  }
+
   logoutUser() {
     return this.postRequest(`${this.USERS_URL}/logout`, null, true);
   }
@@ -245,8 +249,8 @@ const apiService = new (class ApiService extends Ajax {
     return this.postRequest(`${this.USERS_URL}/resend-confirm-registration`, { email });
   }
 
-  updateUserAdHoc(userModifications, tokenObj) {
-    return this.patchRequest(`${this.USERS_URL}/update-adhoc`, { userModifications, tokenObj });
+  setNewPassword(newPassword, token) {
+    return this.patchRequest(`${this.USERS_URL}/set-new-password`, { newPassword, token });
   }
 })();
 

--- a/src/middleware/helpers/mailer.ts
+++ b/src/middleware/helpers/mailer.ts
@@ -1,12 +1,9 @@
 import * as dotenv from 'dotenv';
 import { createTransport } from 'nodemailer';
 import SMTPTransport = require('nodemailer/lib/smtp-transport');
-import getLogger from '../../../utils/logger';
 
 // @ts-ignore
 dotenv.config();
-
-const logger = getLogger(module.filename);
 
 const translations = Object.freeze({
   activationSubject: 'Account activation',
@@ -15,6 +12,15 @@ const translations = Object.freeze({
 
     <p>Thank you for creating a new account. In order to use it, you have to 
     activate it first by clicking on the following link: 
+    <a href="{URL}" target="_blank">{URL}</a></p>
+    <p>The above link will expire after 1 hour.</p>
+  `.trim(),
+  resetPasswordSubject: 'Reset password',
+  resetPasswordMessage: `
+    <h1>Hello from the PEV Shop!</h1>
+
+    <p>We received your request to reset your account's password. In order to do it, you have to 
+    set a new one by clicking on the following link: 
     <a href="{URL}" target="_blank">{URL}</a></p>
     <p>The above link will expire after 1 hour.</p>
   `.trim(),
@@ -29,6 +35,12 @@ const EMAIL_TYPES_CONFIG = Object.freeze({
     subject: translations.activationSubject,
     getMessage(url: string): string {
       return translations.activationMessage.replace(/{URL}/g, url);
+    },
+  },
+  RESET_PASSWORD: {
+    subject: translations.resetPasswordSubject,
+    getMessage(url: string): string {
+      return translations.resetPasswordMessage.replace(/{URL}/g, url);
     },
   },
 } as const);

--- a/src/middleware/routes/api-users.ts
+++ b/src/middleware/routes/api-users.ts
@@ -32,7 +32,9 @@ router._registerUser = registerUser;
 router._confirmRegistration = confirmRegistration;
 router._resendConfirmRegistration = resendConfirmRegistration;
 router._logInUser = logInUser;
+router._resetPassword = resetPassword;
 router._logOutUser = logOutUser;
+router._updateAdHoc = updateAdHoc;
 router._getUser = getUser;
 
 export default router;

--- a/src/middleware/routes/api-users.ts
+++ b/src/middleware/routes/api-users.ts
@@ -166,7 +166,6 @@ async function setNewPassword(req: Request, res: Response): Promise<void | Pick<
   logger.log('(setNewPassword) req.body:', req.body);
 
   try {
-    // @ts-ignore
     const validatedPassword = UserModel.validatePassword(req.body.newPassword);
 
     if (validatedPassword !== '') {
@@ -180,13 +179,6 @@ async function setNewPassword(req: Request, res: Response): Promise<void | Pick<
     const userToSetNewPassword = (await getFromDB(tokenQuery, 'User')) as IUser;
 
     if (userToSetNewPassword) {
-      logger.log(
-        '(setNewPassword) userToSetNewPassword.password:',
-        userToSetNewPassword.password,
-        ' /hashed pass:',
-        hashedPassword
-      );
-
       await updateOneModelInDB(
         tokenQuery,
         {
@@ -280,13 +272,6 @@ async function resendConfirmRegistration(req: Request, res: Response): TPromised
       'User'
     )) as IUser;
 
-    logger.log(
-      'userToResendConfirmation:',
-      userToResendConfirmation,
-      ' /userToResendConfirmation.tokens.confirmRegistration:',
-      userToResendConfirmation.tokens.confirmRegistration
-    );
-
     if (userToResendConfirmation) {
       return await sendRegistrationEmail({
         login: userToResendConfirmation.login,
@@ -348,10 +333,7 @@ async function resetPassword(req: Request, res: Response): Promise<void | Pick<R
     )) as IUser;
 
     if (userToResetPassword) {
-      logger.log('(resetPassword) userToResetPassword:', userToResetPassword.password);
-
       await userToResetPassword.setSingleToken('resetPassword');
-
       await sendResetPasswordEmail({
         email: userToResetPassword.email,
         token: userToResetPassword.tokens.resetPassword as string,

--- a/test/middleware/routes/api-users.spec.ts
+++ b/test/middleware/routes/api-users.spec.ts
@@ -48,7 +48,8 @@ describe('#api-users', () => {
   });
 
   it('should call router.post(..) and router.get(..) specific amount of times with correct params', () => {
-    expect(apiUsersRouter.post).toHaveBeenCalledTimes(6);
+    expect(apiUsersRouter.post).toHaveBeenCalledTimes(7);
+    expect(apiUsersRouter.patch).toHaveBeenCalledTimes(1);
     expect(apiUsersRouter.get).toHaveBeenCalledTimes(1);
 
     expect(apiUsersRouter.post).toHaveBeenNthCalledWith(1, '/api/users/', apiUsersRouter._updateUser);
@@ -64,12 +65,15 @@ describe('#api-users', () => {
       apiUsersRouter._resendConfirmRegistration
     );
     expect(apiUsersRouter.post).toHaveBeenNthCalledWith(5, '/api/users/login', apiUsersRouter._logInUser);
+    expect(apiUsersRouter.post).toHaveBeenNthCalledWith(6, '/api/users/reset-password', apiUsersRouter._resetPassword);
     expect(apiUsersRouter.post).toHaveBeenNthCalledWith(
-      6,
+      7,
       '/api/users/logout',
       authMiddlewareReturnedFn,
       apiUsersRouter._logOutUser
     );
+
+    expect(apiUsersRouter.patch).toHaveBeenCalledWith('/api/users/update-adhoc', apiUsersRouter._updateAdHoc);
     expect(apiUsersRouter.get).toHaveBeenCalledWith(
       '/api/users/:id',
       authMiddlewareReturnedFn,

--- a/test/middleware/routes/api-users.spec.ts
+++ b/test/middleware/routes/api-users.spec.ts
@@ -48,32 +48,33 @@ describe('#api-users', () => {
   });
 
   it('should call router.post(..) and router.get(..) specific amount of times with correct params', () => {
-    expect(apiUsersRouter.post).toHaveBeenCalledTimes(7);
+    expect(apiUsersRouter.post).toHaveBeenCalledTimes(8);
     expect(apiUsersRouter.patch).toHaveBeenCalledTimes(1);
     expect(apiUsersRouter.get).toHaveBeenCalledTimes(1);
 
-    expect(apiUsersRouter.post).toHaveBeenNthCalledWith(1, '/api/users/', apiUsersRouter._updateUser);
-    expect(apiUsersRouter.post).toHaveBeenNthCalledWith(2, '/api/users/register', apiUsersRouter._registerUser);
-    expect(apiUsersRouter.post).toHaveBeenNthCalledWith(
-      3,
+    expect(apiUsersRouter.post).toHaveBeenCalledWith('/api/users/', apiUsersRouter._updateUser);
+    expect(apiUsersRouter.post).toHaveBeenCalledWith('/api/users/register', apiUsersRouter._registerUser);
+    expect(apiUsersRouter.post).toHaveBeenCalledWith(
       '/api/users/confirm-registration',
       apiUsersRouter._confirmRegistration
     );
-    expect(apiUsersRouter.post).toHaveBeenNthCalledWith(
-      4,
+    expect(apiUsersRouter.post).toHaveBeenCalledWith(
       '/api/users/resend-confirm-registration',
       apiUsersRouter._resendConfirmRegistration
     );
-    expect(apiUsersRouter.post).toHaveBeenNthCalledWith(5, '/api/users/login', apiUsersRouter._logInUser);
-    expect(apiUsersRouter.post).toHaveBeenNthCalledWith(6, '/api/users/reset-password', apiUsersRouter._resetPassword);
-    expect(apiUsersRouter.post).toHaveBeenNthCalledWith(
-      7,
+    expect(apiUsersRouter.post).toHaveBeenCalledWith('/api/users/login', apiUsersRouter._logInUser);
+    expect(apiUsersRouter.post).toHaveBeenCalledWith('/api/users/reset-password', apiUsersRouter._resetPassword);
+    expect(apiUsersRouter.post).toHaveBeenCalledWith(
+      '/api/users/resend-reset-password',
+      apiUsersRouter._resendResetPassword
+    );
+    expect(apiUsersRouter.post).toHaveBeenCalledWith(
       '/api/users/logout',
       authMiddlewareReturnedFn,
       apiUsersRouter._logOutUser
     );
 
-    expect(apiUsersRouter.patch).toHaveBeenCalledWith('/api/users/update-adhoc', apiUsersRouter._updateAdHoc);
+    expect(apiUsersRouter.patch).toHaveBeenCalledWith('/api/users/set-new-password', apiUsersRouter._setNewPassword);
     expect(apiUsersRouter.get).toHaveBeenCalledWith(
       '/api/users/:id',
       authMiddlewareReturnedFn,


### PR DESCRIPTION
Partially related to #5.

- add link redirecting to '/reset-password' in `LogIn` component
- add 'api/users/reset-password' and ~~'api/users/update-adhoc'~~ 'api/users/set-new-password' endpoints that respectively send an email with link to reset User account password and redirect to page where User can provide the new password
- unify methods for setting and deleting single token to do it dynamically based on provided token name and extend Schema with `resetPassword` token field
- add `ResetPassword` and `SetNewPassword` view components representing forms to reset password (User email is needed) and set the new one
- extend `ApiService` module with `resetPassword` and ~~`updateUserAdHoc`~~ `setNewPassword` methods to integrate frontend with API
- extend `mailer` module to handle sending emails with content related to resetting password
- add 'api/users/resend-reset-password' API endpoint and extend `ApiService` and frontend accordingly
- change utilizing 3rd-party `uuidv4` method to Node's built-in [`crypto.randomBytes`](https://nodejs.org/api/crypto.html#crypto_crypto_randombytes_size_callback)