### PR TITLE
Refactored frontend routing and extended middleware response wrapper

### DIFF
--- a/src/frontend/components/pages/_routes.js
+++ b/src/frontend/components/pages/_routes.js
@@ -1,0 +1,25 @@
+const ROUTE_GROUPS = Object.freeze({
+  ROOT: '/',
+  PAGES: '/pages',
+  get SHOP() {
+    return `${this.PAGES}/shop`;
+  },
+});
+
+export const ROUTES = Object.freeze({
+  ROOT: ROUTE_GROUPS.ROOT,
+  PAGES: ROUTE_GROUPS.PAGES,
+  SHOP: ROUTE_GROUPS.SHOP,
+  PRODUCT: `${ROUTE_GROUPS.SHOP}/product`,
+  REGISTER: `${ROUTE_GROUPS.PAGES}/register`,
+  CONFIRM_REGISTRATION: `${ROUTE_GROUPS.PAGES}/confirm-registration`,
+  LOG_IN: `${ROUTE_GROUPS.PAGES}/log-in`,
+  NOT_LOGGED_IN: `${ROUTE_GROUPS.PAGES}/not-logged-in`,
+  RESET_PASSWORD: `${ROUTE_GROUPS.PAGES}/reset-password`,
+  SET_NEW_PASSWORD: `${ROUTE_GROUPS.PAGES}/set-new-password`,
+  ACCOUNT: `${ROUTE_GROUPS.PAGES}/account`,
+  COMPARE: `${ROUTE_GROUPS.SHOP}/compare`,
+  ADD_NEW_PRODUCT: `${ROUTE_GROUPS.SHOP}/add-new-product`,
+  MODIFY_PRODUCT: `${ROUTE_GROUPS.SHOP}/modify-product`,
+  ORDER: `${ROUTE_GROUPS.SHOP}/order`,
+});

--- a/src/frontend/components/pages/account.js
+++ b/src/frontend/components/pages/account.js
@@ -1,11 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { useHistory, NavLink, Route, Switch, useRouteMatch } from 'react-router-dom';
+import { useHistory, NavLink, Route, Switch } from 'react-router-dom';
 import storeService from '../../features/storeService';
 import httpService from '../../features/httpService';
 import { SetNewPassword } from '../views/password';
 import userSessionService from '../../features/userSessionService';
 import Popup, { POPUP_TYPES, getClosePopupBtn } from '../utils/popup';
 import ProductItem from '../views/productItem';
+import { ROUTES } from './_routes';
 
 const translations = Object.freeze({
   accountHeader: 'Account',
@@ -114,7 +115,7 @@ function Security() {
             buttons: [getClosePopupBtn(setPopupData)],
           });
         } else {
-          history.replace('/');
+          history.replace(ROUTES.ROOT);
         }
       });
     }
@@ -210,7 +211,6 @@ function Orders() {
 
 export default function Account() {
   // TODO: [PERFORMANCE]? fix rendering component twice when redirected from LogIn page
-  const { path, url } = useRouteMatch();
   const MENU_ITEMS = Object.freeze([
     {
       url: 'user-profile',
@@ -242,14 +242,14 @@ export default function Account() {
         <ul className="account__menu-nav">
           {MENU_ITEMS.map((item) => (
             <li key={item.url}>
-              <NavLink to={`${url}/${item.url}`}>{item.translation}</NavLink>
+              <NavLink to={`${ROUTES.ACCOUNT}/${item.url}`}>{item.translation}</NavLink>
             </li>
           ))}
         </ul>
 
         <Switch>
           {MENU_ITEMS.map((item) => (
-            <Route path={`${path}/${item.url}`} key={item.url}>
+            <Route path={`${ROUTES.ACCOUNT}/${item.url}`} key={item.url}>
               {item.component}
             </Route>
           ))}

--- a/src/frontend/components/pages/confirmRegistration.js
+++ b/src/frontend/components/pages/confirmRegistration.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 import httpService from '../../features/httpService';
+import { ROUTES } from './_routes';
 
 const translations = Object.freeze({
   header: 'Registration confirmation',
@@ -56,7 +57,7 @@ export default function ConfirmRegistration() {
     }
   }, []);
 
-  const logIn = () => history.push('/log-in');
+  const logIn = () => history.push(ROUTES.LOG_IN);
 
   return (
     <section>

--- a/src/frontend/components/pages/logIn.js
+++ b/src/frontend/components/pages/logIn.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import userSessionService from '../../features/userSessionService';
+import { ROUTES } from './_routes';
 
 const translations = Object.freeze({
   logInHeader: 'Login to shop',
@@ -36,7 +37,7 @@ export default function LogIn() {
         TODO: [UX] redirect to the page where user was before logging in 
         OR just close/fold the form, if it is presented as a aside/sticky panel
       */
-      history.push('/');
+      history.push(ROUTES.ROOT);
     });
   };
 
@@ -74,7 +75,7 @@ export default function LogIn() {
 
       <div>
         <p>{translations.resetPasswordHint}</p>
-        <Link to={'/reset-password'}>{translations.resetPasswordLink}</Link>
+        <Link to={ROUTES.RESET_PASSWORD}>{translations.resetPasswordLink}</Link>
       </div>
 
       {/* TODO: [UX] if User account is not confirmed, show an info with hint to re-send activation email */}

--- a/src/frontend/components/pages/notFound.js
+++ b/src/frontend/components/pages/notFound.js
@@ -1,0 +1,7 @@
+const translations = Object.freeze({
+  notFoundHeader: 'Page not found!',
+});
+
+export default function NotFound() {
+  return translations.notFoundHeader;
+}

--- a/src/frontend/components/pages/register.js
+++ b/src/frontend/components/pages/register.js
@@ -4,6 +4,7 @@ import { useHistory } from 'react-router-dom';
 import httpService from '../../features/httpService';
 import Popup, { POPUP_TYPES, getClosePopupBtn } from '../utils/popup';
 import { PasswordField } from '../views/password';
+import { ROUTES } from './_routes';
 
 const translations = Object.freeze({
   registerHeader: 'Account registration',
@@ -70,7 +71,7 @@ export default function Register() {
             altMessage: translations.registrationSuccessAltMsg,
             buttons: [
               {
-                onClick: () => history.push('/log-in'),
+                onClick: () => history.push(ROUTES.LOG_IN),
                 text: translations.popupGoToLogin,
               },
             ],

--- a/src/frontend/components/pages/shop.js
+++ b/src/frontend/components/pages/shop.js
@@ -2,8 +2,13 @@ import React, { memo /*, useState*/ } from 'react';
 import { Route, Switch } from 'react-router-dom';
 
 // import CategoriesTree from '../views/categoriesTree';
+import { ROUTES } from '../pages/_routes';
 import ProductList from '../views/productList';
 import ProductDetails from '../views/productDetails';
+import { NewProduct, ModifyProduct } from '../pages/newProduct';
+import Compare from '../pages/compare';
+import Order from '../pages/order';
+import NotFound from '../pages/notFound';
 
 // const ShopMenuChooser = memo(function ShopMenuChooser(props) {
 //   return (
@@ -61,12 +66,28 @@ function Shop() {
       {/*{showChooser()}*/}
 
       <Switch>
-        <Route path="/shop" exact>
+        <Route path={ROUTES.SHOP} exact>
           <ProductList />
           {/*{showChosenProductsView()}*/}
         </Route>
-        <Route path="/shop/:productName">
+        <Route path={`${ROUTES.PRODUCT}/:productName`}>
           <ProductDetails />
+        </Route>
+        <Route path={ROUTES.COMPARE}>
+          <Compare />
+        </Route>
+        <Route path={ROUTES.ADD_NEW_PRODUCT}>
+          <NewProduct />
+        </Route>
+        <Route path={ROUTES.MODIFY_PRODUCT}>
+          <ModifyProduct />
+        </Route>
+        <Route path={ROUTES.ORDER}>
+          <Order />
+        </Route>
+
+        <Route>
+          <NotFound />
         </Route>
       </Switch>
     </section>

--- a/src/frontend/components/views/cart.js
+++ b/src/frontend/components/views/cart.js
@@ -3,6 +3,7 @@ import { useHistory } from 'react-router-dom';
 import { observer } from 'mobx-react-lite';
 import storageService from '../../features/storageService';
 import storeService from '../../features/storeService';
+import { ROUTES } from '../pages/_routes';
 
 export default observer(function Cart() {
   const [cartVisibility, updateCartVisibility] = useState(false);
@@ -40,7 +41,7 @@ export default observer(function Cart() {
   };
 
   const handleCartSubmission = () => {
-    history.push('/order');
+    history.push(ROUTES.ORDER);
   };
 
   return (

--- a/src/frontend/components/views/compareProducts.js
+++ b/src/frontend/components/views/compareProducts.js
@@ -4,6 +4,7 @@ import { observer } from 'mobx-react-lite';
 import storeService from '../../features/storeService';
 import { Link } from 'react-router-dom';
 import Scroller from '../utils/scroller';
+import { ROUTES } from '../pages/_routes';
 
 const List = observer(function CompareProducts() {
   const translations = {
@@ -49,7 +50,7 @@ const List = observer(function CompareProducts() {
       />
 
       <div className="compare-products-candidates__actions">
-        <Link to={{ pathname: `/compare` }}> {translations.compareProducts}</Link>
+        <Link to={{ pathname: ROUTES.COMPARE }}> {translations.compareProducts}</Link>
         <button onClick={handleClearCompareProducts}>{translations.clearComparableProducts}</button>
       </div>
     </aside>

--- a/src/frontend/components/views/main.js
+++ b/src/frontend/components/views/main.js
@@ -5,17 +5,16 @@ import { observer } from 'mobx-react-lite';
 import storeService from '../../features/storeService';
 import userSessionService from '../../features/userSessionService';
 
+import { ROUTES } from '../pages/_routes';
 import Home from '../pages/home';
 import Shop from '../pages/shop';
-import { NewProduct, ModifyProduct } from '../pages/newProduct';
 import Register from '../pages/register';
 import NotLoggedIn from '../pages/notLoggedIn';
 import LogIn from '../pages/logIn';
 import Account from '../pages/account';
-import Compare from '../pages/compare';
-import Order from '../pages/order';
 import ConfirmRegistration from '../pages/confirmRegistration';
 import { SetNewPassword, ResetPassword } from '../views/password';
+import NotFound from '../pages/notFound';
 import { GenericErrorPopup } from '../utils/popup';
 
 export default observer(function Main() {
@@ -29,48 +28,43 @@ export default observer(function Main() {
   return (
     <main className="main">
       <Switch>
-        <Route path="/" exact>
+        <Route path={ROUTES.ROOT} exact>
           <Home />
         </Route>
-        <Route path="/shop">
-          <Shop />
+
+        <Route path={ROUTES.PAGES}>
+          <Route path={ROUTES.SHOP}>
+            <Shop />
+          </Route>
+          <Route path={ROUTES.REGISTER}>
+            <Register />
+          </Route>
+          <Route path={ROUTES.CONFIRM_REGISTRATION}>
+            <ConfirmRegistration />
+          </Route>
+          <Route path={ROUTES.LOG_IN}>
+            <LogIn />
+          </Route>
+          <Route path={ROUTES.NOT_LOGGED_IN}>
+            <NotLoggedIn />
+          </Route>
+          <Route path={ROUTES.RESET_PASSWORD}>
+            <ResetPassword />
+          </Route>
+          <Route path={ROUTES.SET_NEW_PASSWORD}>
+            <SetNewPassword contextType={SetNewPassword.CONTEXT_TYPES.LOGGED_OUT} />
+          </Route>
+          <Route path={ROUTES.ACCOUNT}>
+            {
+              /* TODO: [BUG] show loader for the time `storeService.userAccountState` is updated by MobX 
+              to prevent redirecting when user indeed has session */
+              storeService.userAccountState ? <Account /> : <Redirect to={ROUTES.NOT_LOGGED_IN} />
+            }
+          </Route>
         </Route>
-        <Route path="/compare">
-          <Compare />
-        </Route>
-        <Route path="/add-new-product">
-          <NewProduct />
-        </Route>
-        <Route path="/modify-product">
-          <ModifyProduct />
-        </Route>
-        <Route path="/not-logged-in">
-          <NotLoggedIn />
-        </Route>
-        <Route path="/register">
-          <Register />
-        </Route>
-        <Route path="/confirm-registration">
-          <ConfirmRegistration />
-        </Route>
-        <Route path="/log-in">
-          <LogIn />
-        </Route>
-        <Route path="/reset-password">
-          <ResetPassword />
-        </Route>
-        <Route path="/set-new-password">
-          <SetNewPassword contextType={SetNewPassword.CONTEXT_TYPES.LOGGED_OUT} />
-        </Route>
-        <Route path="/account">
-          {
-            /* TODO: [BUG] show loader for the time `storeService.userAccountState` is updated by MobX 
-            to prevent redirecting when user indeed has session */
-            storeService.userAccountState ? <Account /> : <Redirect to="/not-logged-in" />
-          }
-        </Route>
-        <Route path="/order">
-          <Order />
+
+        <Route>
+          <NotFound />
         </Route>
       </Switch>
 

--- a/src/frontend/components/views/nav.js
+++ b/src/frontend/components/views/nav.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { observer } from 'mobx-react-lite';
 import storeService from '../../features/storeService';
 import userSessionService from '../../features/userSessionService';
+import { ROUTES } from '../pages/_routes';
 
 const translations = Object.freeze({
   start: 'Start',
@@ -24,7 +25,7 @@ export default observer(function Nav() {
         return;
       }
 
-      history.replace('/');
+      history.replace(ROUTES.ROOT);
     });
   };
 
@@ -32,31 +33,31 @@ export default observer(function Nav() {
     <nav className="nav">
       <ul>
         <li>
-          <Link to="/">{translations.start}</Link>
+          <Link to={ROUTES.ROOT}>{translations.start}</Link>
         </li>
         <li>
-          <Link to="/shop">{translations.shop}</Link>
+          <Link to={ROUTES.SHOP}>{translations.shop}</Link>
         </li>
         <li>
-          <Link to="/add-new-product">{translations.addNewProduct}</Link>
+          <Link to={ROUTES.ADD_NEW_PRODUCT}>{translations.addNewProduct}</Link>
         </li>
         <li>
-          <Link to="/modify-product">{translations.modifyProduct}</Link>
+          <Link to={ROUTES.MODIFY_PRODUCT}>{translations.modifyProduct}</Link>
         </li>
         <li>
           {storeService.userAccountState ? (
-            <Link to="/" onClick={logOutUser}>
+            <Link to={ROUTES.ROOT} onClick={logOutUser}>
               {translations.logOut}
             </Link>
           ) : (
-            <Link to="/log-in">{translations.logIn}</Link>
+            <Link to={ROUTES.LOG_IN}>{translations.logIn}</Link>
           )}
         </li>
         <li>
           {storeService.userAccountState ? (
-            <Link to="/account">{translations.account}</Link>
+            <Link to={ROUTES.ACCOUNT}>{translations.account}</Link>
           ) : (
-            <Link to="/register">{translations.register}</Link>
+            <Link to={ROUTES.REGISTER}>{translations.register}</Link>
           )}
         </li>
       </ul>

--- a/src/frontend/components/views/password.js
+++ b/src/frontend/components/views/password.js
@@ -4,6 +4,7 @@ import { Formik, Field } from 'formik';
 import FormFieldError from '../utils/formFieldError';
 import httpService from '../../features/httpService';
 import Popup, { POPUP_TYPES, getClosePopupBtn } from '../utils/popup';
+import { ROUTES } from '../pages/_routes';
 
 const translations = Object.freeze({
   resetPasswordHeader: 'Reset password',
@@ -203,7 +204,7 @@ function SetNewPassword({ contextType }) {
               message: translations.setNewPasswordSuccessMsg,
               buttons: [
                 {
-                  onClick: () => history.push('/log-in'),
+                  onClick: () => history.push(ROUTES.LOG_IN),
                   text: translations.popupGoToLogIn,
                 },
               ],

--- a/src/frontend/components/views/productDetails.js
+++ b/src/frontend/components/views/productDetails.js
@@ -7,6 +7,7 @@ import Popup, { POPUP_TYPES, getClosePopupBtn } from '../utils/popup';
 import RatingWidget from '../utils/ratingWidget';
 import { getLocalizedDate } from '../../features/localization';
 import storeService from '../../features/storeService';
+import { ROUTES } from '../pages/_routes';
 
 const productDetailsTranslations = Object.freeze({
   category: 'Category',
@@ -310,6 +311,7 @@ export default function ProductDetails({ product }) {
   const [productDetails, setProductDetails] = useState([]);
   const [renderRelatedProducts, setRenderRelatedProducts] = useState(false);
   const [popupData, setPopupData] = useState(null);
+  // TODO: [BUG] update `isProductObserved` when component is re-rendered due to `product` prop param change
   const [isProductObserved, setIsProductObserved] = useState(
     (storeService.userAccountState?.observedProductsIDs || []).some(
       (observedProductID) => observedProductID === product._id
@@ -328,7 +330,7 @@ export default function ProductDetails({ product }) {
         }
       })
       .catch((error) => console.warn('TODO: fix relatedProducts! /error:', error));
-  }, []);
+  }, [product]);
 
   const getMainDetailsContent = () =>
     Object.entries(productDetails)
@@ -349,7 +351,7 @@ export default function ProductDetails({ product }) {
       ));
 
   const navigateToProductModify = () => {
-    history.push('/modify-product', productDetails.name);
+    history.push(ROUTES.MODIFY_PRODUCT, productDetails.name);
   };
 
   const deleteProduct = () => {
@@ -365,7 +367,7 @@ export default function ProductDetails({ product }) {
             message: 'Product successfully deleted!',
             buttons: [
               {
-                onClick: () => history.push('/shop'),
+                onClick: () => history.push(ROUTES.SHOP),
                 text: 'Go back to shop',
               },
             ],
@@ -390,7 +392,7 @@ export default function ProductDetails({ product }) {
         buttons: [
           {
             text: productDetailsTranslations.goTologIn,
-            onClick: () => history.push(`/log-in`),
+            onClick: () => history.push(ROUTES.LOG_IN),
           },
           getClosePopupBtn(setPopupData),
         ],
@@ -414,6 +416,7 @@ export default function ProductDetails({ product }) {
             buttons: [getClosePopupBtn(setPopupData)],
           });
         } else {
+          // TODO: [BUG] update observed products IDs list in storage
           storeService.updateUserAccountState({
             ...storeService.userAccountState,
             observedProductsIDs: res,

--- a/src/frontend/components/views/productItem.js
+++ b/src/frontend/components/views/productItem.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import storeService from '../../features/storeService';
+import { ROUTES } from '../pages/_routes';
 import CompareProduct from './compareProducts';
 
 const translations = {
@@ -18,7 +19,7 @@ export function ProductItemLink({ productData }) {
   return (
     <Link
       to={{
-        pathname: `/shop/${productData.url}`,
+        pathname: `${ROUTES.PRODUCT}/${productData.url}`,
         state: productData,
       }}
     >

--- a/src/middleware/features/auth.ts
+++ b/src/middleware/features/auth.ts
@@ -6,7 +6,7 @@ import * as dotenv from 'dotenv';
 import fetch, { RequestInit, Response as FetchResponse } from 'node-fetch';
 import { IUser } from '../../database/models/_user';
 import { HTTP_STATUS_CODE } from '../../types';
-import { embraceResponse } from '../helpers/middleware-response-wrapper';
+import { wrapRes } from '../helpers/middleware-response-wrapper';
 
 // @ts-ignore
 dotenv.default.config();
@@ -49,21 +49,21 @@ const authMiddlewareFn = (
       const authToken = req.header('Authorization');
 
       if (!authToken) {
-        return res
-          .status(HTTP_STATUS_CODE.BAD_REQUEST)
-          .json(embraceResponse({ error: 'Authorization token header is empty or not attached!' }));
+        return wrapRes(res, HTTP_STATUS_CODE.BAD_REQUEST, {
+          error: 'Authorization token header is empty or not attached!',
+        });
       } else if (!authToken.startsWith(BEARER_TOKEN_PREFIX)) {
-        return res
-          .status(HTTP_STATUS_CODE.BAD_REQUEST)
-          .json(embraceResponse({ error: `Auth token value does not start with '${BEARER_TOKEN_PREFIX}'!` }));
+        return wrapRes(res, HTTP_STATUS_CODE.BAD_REQUEST, {
+          error: `Auth token value does not start with '${BEARER_TOKEN_PREFIX}'!`,
+        });
       }
 
       const bearerToken = authToken.replace(BEARER_TOKEN_PREFIX, '');
 
       if (!bearerToken) {
-        return res
-          .status(HTTP_STATUS_CODE.BAD_REQUEST)
-          .json(embraceResponse({ error: 'Auth token does not contain bearer value!' }));
+        return wrapRes(res, HTTP_STATUS_CODE.BAD_REQUEST, {
+          error: 'Auth token does not contain bearer value!',
+        });
       }
 
       const decodedToken = verifyToken(bearerToken);
@@ -73,7 +73,7 @@ const authMiddlewareFn = (
       )) as IUser | IUser[];
 
       if (!user || (user as IUser[]).length === 0) {
-        return res.status(HTTP_STATUS_CODE.NOT_FOUND).json(embraceResponse({ error: 'User to authorize not found!' }));
+        return wrapRes(res, HTTP_STATUS_CODE.NOT_FOUND, { error: 'User to authorize not found!' });
       }
 
       // TODO: [REFACTOR] normalize data returned by `getFromDB`
@@ -91,7 +91,7 @@ const userRoleMiddlewareFn = (roleName: string): any => {
   return async (req: Request & { user: any; userPermissions: string[] }, res: Response, next: NextFunction) => {
     try {
       if (!req.user) {
-        return res.status(HTTP_STATUS_CODE.FORBIDDEN).json(embraceResponse({ error: `You don't have permissions!` }));
+        return wrapRes(res, HTTP_STATUS_CODE.FORBIDDEN, { error: `You don't have permissions!` });
       }
 
       // TODO: improve selecting data while populating

--- a/src/middleware/helpers/middleware-error-handler.ts
+++ b/src/middleware/helpers/middleware-error-handler.ts
@@ -1,7 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import type { TLogger } from '../../../utils/logger';
 import { HTTP_STATUS_CODE } from '../../types';
-import { embraceResponse } from './middleware-response-wrapper';
+import { wrapRes } from './middleware-response-wrapper';
 
 type TMiddlewareErrorHandler = (error: Error, req: Request, res: Response) => Pick<Response, 'json'>;
 
@@ -17,14 +17,12 @@ export default function getMiddlewareErrorHandler(logger: TLogger): TMiddlewareE
   ): Pick<Response, 'json'> {
     logger.error(`${GENERIC_ERROR_MESSAGE}\n/message:`, error.message, '\n/stack:', error.stack);
 
-    return res.status(HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR).json(
-      embraceResponse({
-        exception: {
-          message: error.message || GENERIC_ERROR_MESSAGE,
-          // TODO: [SECURITY] disable exposing stack in production mode
-          stack: error.stack,
-        },
-      })
-    );
+    return wrapRes(res, HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR, {
+      exception: {
+        message: error.message || GENERIC_ERROR_MESSAGE,
+        // TODO: [SECURITY] disable exposing stack in production mode
+        stack: error.stack,
+      },
+    });
   };
 }

--- a/src/middleware/helpers/middleware-response-wrapper.ts
+++ b/src/middleware/helpers/middleware-response-wrapper.ts
@@ -1,3 +1,5 @@
+import type { Response } from 'express';
+
 interface IEmbracedResponse {
   // TODO: [REFACTOR] 'authToken' could be always paired with 'payload' prop or be contained by it
   authToken: string | null;
@@ -5,6 +7,67 @@ interface IEmbracedResponse {
   message: string;
   error: string;
   exception: Error | { message: string; stack?: string };
+}
+
+const HTTP_STATUS_CODES = Object.freeze({
+  SUCCESSFUL: {
+    200: 200,
+    201: 201,
+    204: 204,
+  },
+  CLIENT_ERROR: {
+    400: 400,
+    401: 401,
+    403: 403,
+    404: 404,
+    409: 409,
+  },
+  SERVER_ERROR: {
+    500: 500,
+    511: 511,
+  },
+});
+
+type TypeOfHTTPStatusCodes = typeof HTTP_STATUS_CODES;
+
+const mappedHTTPStatusCode = Object.freeze({
+  200: 'SUCCESSFUL',
+  201: 'SUCCESSFUL',
+  204: 'SUCCESSFUL',
+  400: 'CLIENT_ERROR',
+  401: 'CLIENT_ERROR',
+  403: 'CLIENT_ERROR',
+  404: 'CLIENT_ERROR',
+  409: 'CLIENT_ERROR',
+  500: 'SERVER_ERROR',
+  511: 'SERVER_ERROR',
+});
+
+type TSuccessfulHTTPStatusCodesToData = {
+  [SuccessfulStatus in keyof TypeOfHTTPStatusCodes['SUCCESSFUL']]: 'payload' | 'message';
+};
+type TClientErrorHTTPStatusCodesToData = {
+  [ClientErrorStatus in keyof TypeOfHTTPStatusCodes['CLIENT_ERROR']]: 'error';
+};
+type TServerErrorHTTPStatusCodesToData = {
+  [ServerErrorStatus in keyof TypeOfHTTPStatusCodes['SERVER_ERROR']]: 'exception';
+};
+
+type THTTPStatusCodeToData = TSuccessfulHTTPStatusCodesToData &
+  TClientErrorHTTPStatusCodesToData &
+  TServerErrorHTTPStatusCodesToData;
+
+function responseWrapper<
+  Status extends keyof typeof mappedHTTPStatusCode,
+  DataKey extends keyof IEmbracedResponse extends infer K
+    ? K extends keyof IEmbracedResponse
+      ? K extends THTTPStatusCodeToData[Status]
+        ? K
+        : never
+      : never
+    : never
+>(res: Response, status: Status, data: Record<DataKey, IEmbracedResponse[DataKey]>) {
+  return res.status(status).json(data);
 }
 
 export const embraceResponse = <Key extends keyof IEmbracedResponse>(response: Record<Key, IEmbracedResponse[Key]>) =>

--- a/src/middleware/middleware-index.ts
+++ b/src/middleware/middleware-index.ts
@@ -15,6 +15,7 @@ import apiUserRoles from './routes/api-user-roles';
 import apiOrders from './routes/api-orders';
 import * as dotenv from 'dotenv';
 import { HTTP_STATUS_CODE } from '../types';
+import { wrapRes } from '../middleware/helpers/middleware-response-wrapper';
 
 // @ts-ignore
 dotenv.default.config();
@@ -35,7 +36,7 @@ const middleware = (app: Application): void => {
       .catch((error) => {
         logger.log('Image searching error: ', error, ' /imagePath: ', imagePath);
 
-        return res.status(HTTP_STATUS_CODE.NOT_FOUND).end();
+        return wrapRes(res, HTTP_STATUS_CODE.NOT_FOUND).end();
       });
   });
 };

--- a/src/middleware/routes/api-orders.ts
+++ b/src/middleware/routes/api-orders.ts
@@ -6,7 +6,7 @@ import { getFromDB } from '../../database/database-index';
 import { authToPayU as getToken } from '../features/auth';
 import { HTTP_STATUS_CODE, IPayByLinkMethod, IProductInOrder } from '../../types';
 import { getMinAndMaxPrice, getOrderBody, getOrderHeaders, getOrderPaymentMethod } from '../helpers/payu-api';
-import { embraceResponse } from '../helpers/middleware-response-wrapper';
+import { wrapRes, TypeOfHTTPStatusCodes } from '../helpers/middleware-response-wrapper';
 
 const {
   // @ts-ignore
@@ -48,9 +48,9 @@ router.post('/api/orders', async (req: Request, res: Response) => {
   const token: string | Error = await getToken();
   if (typeof token !== 'string') {
     // TODO: improve error handling
-    return res
-      .status(HTTP_STATUS_CODE.NETWORK_AUTH_REQUIRED)
-      .json(embraceResponse({ error: `Server failed to auth to PayU API due to: ${token?.message}` }));
+    return wrapRes(res, HTTP_STATUS_CODE.NETWORK_AUTH_REQUIRED, {
+      exception: Error(`Server failed to auth to PayU API due to: ${token?.message}`),
+    });
   }
 
   const [minPrice, maxPrice] = getMinAndMaxPrice(products);
@@ -73,12 +73,16 @@ router.post('/api/orders', async (req: Request, res: Response) => {
       logger.log('PayU order response:', resValue, ' /status:', response.status, ' /statusText:', response.statusText);
 
       // TODO: [REFACTOR] respond with either 'msg', 'payload' or 'error' depending or `response.status`
-      return res.status(response.status).json(embraceResponse({ payload: resValue }));
+      return wrapRes(
+        res,
+        response.status as Extract<TypeOfHTTPStatusCodes, 'SUCCESSFUL' | 'CLIENT_ERROR' | 'SERVER_ERROR'>,
+        { payload: resValue }
+      );
     })
     .catch((error: FetchError) => {
       logger.error('PayU order error:', error);
 
-      return res.status(HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR).json(embraceResponse({ exception: error }));
+      return wrapRes(res, HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR, { exception: error });
     });
 });
 

--- a/src/middleware/routes/api-product-categories.ts
+++ b/src/middleware/routes/api-product-categories.ts
@@ -4,7 +4,7 @@ import * as expressModule from 'express';
 import { getFromDB } from '../../database/database-index';
 import { HTTP_STATUS_CODE } from '../../types';
 import getMiddlewareErrorHandler from '../helpers/middleware-error-handler';
-import { embraceResponse } from '../helpers/middleware-response-wrapper';
+import { wrapRes } from '../helpers/middleware-response-wrapper';
 
 const {
   // @ts-ignore
@@ -59,12 +59,12 @@ async function getProductCategoriesHierarchy(req: Request, res: Response, next: 
     const productCategories = (await getFromDB('category', 'Product', { isDistinct: true })) as string[];
 
     if (!productCategories) {
-      return res.status(HTTP_STATUS_CODE.NOT_FOUND).json(embraceResponse({ error: 'Product categories not found!' }));
+      return wrapRes(res, HTTP_STATUS_CODE.NOT_FOUND, { error: 'Product categories not found!' });
     }
 
     const categoriesHierarchy = createCategoriesHierarchy(productCategories);
 
-    return res.status(HTTP_STATUS_CODE.OK).json(embraceResponse({ payload: categoriesHierarchy }));
+    return wrapRes(res, HTTP_STATUS_CODE.OK, { payload: categoriesHierarchy });
   } catch (exception) {
     return next(exception);
   }

--- a/src/middleware/routes/api-users.ts
+++ b/src/middleware/routes/api-users.ts
@@ -88,7 +88,8 @@ const sendRegistrationEmail = async ({
   return sendMail(
     email,
     EMAIL_TYPES.ACTIVATION,
-    `http://localhost:${process.env.PORT}/confirm-registration/?token=${token}`
+    /* TODO: [DX] take "pages" from _routeGroups.js module */
+    `http://localhost:${process.env.PORT}/pages/confirm-registration/?token=${token}`
   )
     .then(async (emailSentInfo) => {
       if (emailSentInfo.rejected.length) {
@@ -127,7 +128,8 @@ const sendResetPasswordEmail = async ({ email, token, res }: { email: string; to
   return sendMail(
     email,
     EMAIL_TYPES.RESET_PASSWORD,
-    `http://localhost:${process.env.PORT}/set-new-password/?token=${token}`
+    /* TODO: [DX] take "pages" from _routeGroups.js module */
+    `http://localhost:${process.env.PORT}/pages/set-new-password/?token=${token}`
   )
     .then(async (emailSentInfo) => {
       if (emailSentInfo.rejected.length) {

--- a/src/middleware/routes/api-users.ts
+++ b/src/middleware/routes/api-users.ts
@@ -8,7 +8,7 @@ import UserModel, { IUser } from '../../database/models/_user';
 import sendMail, { EMAIL_TYPES } from '../helpers/mailer';
 import { HTTP_STATUS_CODE } from '../../types';
 import getMiddlewareErrorHandler from '../helpers/middleware-error-handler';
-import { embraceResponse, normalizePayloadType } from '../helpers/middleware-response-wrapper';
+import { wrapRes } from '../helpers/middleware-response-wrapper';
 
 dotenv.config();
 
@@ -97,16 +97,12 @@ const sendRegistrationEmail = async ({
 
         await deleteFromDB({ name: login }, 'User');
 
-        return res.status(HTTP_STATUS_CODE.BAD_REQUEST).json(
-          embraceResponse({
-            error: `Sending email rejected: ${emailSentInfo.rejected}!`,
-          })
-        );
+        return wrapRes(res, HTTP_STATUS_CODE.BAD_REQUEST, {
+          error: `Sending email rejected: ${emailSentInfo.rejected}!`,
+        });
       }
 
-      return res
-        .status(HTTP_STATUS_CODE.CREATED)
-        .json(embraceResponse({ message: 'User account created! Check your email.' }));
+      return wrapRes(res, HTTP_STATUS_CODE.CREATED, { message: 'User account created! Check your email.' });
     })
     .catch(async (emailSentError: Error) => {
       logger.error('emailSentError:', emailSentError);
@@ -114,13 +110,11 @@ const sendRegistrationEmail = async ({
       await deleteFromDB({ name: login }, 'User');
 
       // next(new Error())
-      return res.status(HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR).json(
-        embraceResponse({
-          exception: {
-            message: `Email sent error: '${emailSentError.message}'!`,
-          },
-        })
-      );
+      return wrapRes(res, HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR, {
+        exception: {
+          message: `Email sent error: '${emailSentError.message}'!`,
+        },
+      });
     });
 };
 
@@ -135,29 +129,23 @@ const sendResetPasswordEmail = async ({ email, token, res }: { email: string; to
       if (emailSentInfo.rejected.length) {
         logger.error('emailSentInfo.rejected:', emailSentInfo.rejected);
 
-        return res.status(HTTP_STATUS_CODE.BAD_REQUEST).json(
-          embraceResponse({
-            exception: {
-              message: `Sending email rejection: ${emailSentInfo.rejected}`,
-            },
-          })
-        );
+        return wrapRes(res, HTTP_STATUS_CODE.BAD_REQUEST, {
+          error: `Sending email rejection: ${emailSentInfo.rejected}`,
+        });
       }
 
-      return res
-        .status(HTTP_STATUS_CODE.OK)
-        .json(embraceResponse({ message: 'Password resetting process began! Check your email.' }));
+      return wrapRes(res, HTTP_STATUS_CODE.OK, {
+        message: 'Password resetting process began! Check your email.',
+      });
     })
     .catch(async (emailSentError) => {
       logger.error('emailSentError:', emailSentError);
 
-      return res.status(HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR).json(
-        embraceResponse({
-          exception: {
-            message: `Email sent error: '${emailSentError.message}'!`,
-          },
-        })
-      );
+      return wrapRes(res, HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR, {
+        exception: {
+          message: `Email sent error: '${emailSentError.message}'!`,
+        },
+      });
     });
 };
 
@@ -185,10 +173,10 @@ async function updateUser(req: Request, res: Response, next: NextFunction) {
     );
 
     if (!updatedUser) {
-      return res.status(HTTP_STATUS_CODE.NOT_FOUND).json(embraceResponse({ error: 'User to update was not found!' }));
+      return wrapRes(res, HTTP_STATUS_CODE.NOT_FOUND, { error: 'User to update was not found!' });
     }
 
-    return res.status(HTTP_STATUS_CODE.CREATED).json(embraceResponse({ message: 'Success!' }));
+    return wrapRes(res, HTTP_STATUS_CODE.CREATED, { message: 'Success!' });
   } catch (exception) {
     return next(exception);
   }
@@ -199,15 +187,15 @@ async function setNewPassword(req: Request, res: Response, next: NextFunction) {
 
   try {
     if (!req.body || !req.body.newPassword || !req.body.token) {
-      return res
-        .status(HTTP_STATUS_CODE.BAD_REQUEST)
-        .json(embraceResponse({ error: 'Request body or "newPassword" or "token" fields are empty!' }));
+      return wrapRes(res, HTTP_STATUS_CODE.BAD_REQUEST, {
+        error: 'Request body or "newPassword" or "token" fields are empty!',
+      });
     }
 
     const validatedPasswordMsg = UserModel.validatePassword(req.body.newPassword);
 
     if (validatedPasswordMsg !== '') {
-      return res.status(HTTP_STATUS_CODE.BAD_REQUEST).json(embraceResponse({ error: validatedPasswordMsg }));
+      return wrapRes(res, HTTP_STATUS_CODE.BAD_REQUEST, { error: validatedPasswordMsg });
     }
 
     const hashedPassword = await hashPassword(req.body.newPassword);
@@ -231,9 +219,9 @@ async function setNewPassword(req: Request, res: Response, next: NextFunction) {
 
       await userToSetNewPassword.deleteSingleToken('resetPassword');
 
-      return res.status(HTTP_STATUS_CODE.CREATED).json(embraceResponse({ message: 'Password updated!' }));
+      return wrapRes(res, HTTP_STATUS_CODE.CREATED, { message: 'Password updated!' });
     } else {
-      return res.status(HTTP_STATUS_CODE.NOT_FOUND).json(embraceResponse({ error: 'User not found!' }));
+      return wrapRes(res, HTTP_STATUS_CODE.NOT_FOUND, { error: 'User not found!' });
     }
   } catch (exception) {
     return next(exception);
@@ -250,7 +238,7 @@ async function registerUser(req: Request, res: Response, next: NextFunction) {
     const validatedPasswordMsg = UserModel.validatePassword(req.body.password);
 
     if (validatedPasswordMsg !== '') {
-      return res.status(HTTP_STATUS_CODE.BAD_REQUEST).json(embraceResponse({ error: validatedPasswordMsg }));
+      return wrapRes(res, HTTP_STATUS_CODE.BAD_REQUEST, { error: validatedPasswordMsg });
     }
 
     req.body.password = await hashPassword(req.body.password);
@@ -274,9 +262,7 @@ async function confirmRegistration(req: Request, res: Response, next: NextFuncti
 
   try {
     if (!req.body.token) {
-      return res
-        .status(HTTP_STATUS_CODE.BAD_REQUEST)
-        .json(embraceResponse({ error: 'Token is empty or not attached!' }));
+      return wrapRes(res, HTTP_STATUS_CODE.BAD_REQUEST, { error: 'Token is empty or not attached!' });
     }
 
     const userToConfirm = (await getFromDB(
@@ -288,9 +274,9 @@ async function confirmRegistration(req: Request, res: Response, next: NextFuncti
       await userToConfirm.confirmUser();
       await userToConfirm.deleteSingleToken('confirmRegistration');
 
-      return res.status(HTTP_STATUS_CODE.OK).json(embraceResponse({ payload: { isUserConfirmed: true } }));
+      return wrapRes(res, HTTP_STATUS_CODE.OK, { payload: { isUserConfirmed: true } });
     } else {
-      return res.status(HTTP_STATUS_CODE.NOT_FOUND).json(embraceResponse({ payload: { isUserConfirmed: false } }));
+      return wrapRes(res, HTTP_STATUS_CODE.NOT_FOUND, { error: 'User could not be confirmed!' });
     }
   } catch (exception) {
     return next(exception);
@@ -303,9 +289,7 @@ async function resendConfirmRegistration(req: Request, res: Response, next: Next
 
   try {
     if (!req.body.email) {
-      return res
-        .status(HTTP_STATUS_CODE.BAD_REQUEST)
-        .json(embraceResponse({ error: 'Email is empty or not attached!' }));
+      return wrapRes(res, HTTP_STATUS_CODE.BAD_REQUEST, { error: 'Email is empty or not attached!' });
     }
 
     const userToResendConfirmation = (await getFromDB(
@@ -325,7 +309,7 @@ async function resendConfirmRegistration(req: Request, res: Response, next: Next
         res,
       });
     } else {
-      return res.status(HTTP_STATUS_CODE.NOT_FOUND).json(embraceResponse({ payload: { isConfirmationReSend: false } }));
+      return wrapRes(res, HTTP_STATUS_CODE.NOT_FOUND, { error: 'Could not resend user confirmation!' });
     }
   } catch (exception) {
     return next(exception);
@@ -337,41 +321,33 @@ async function logInUser(req: Request, res: Response, next: NextFunction) {
     logger.log('(logInUser) req.body:', req.body);
 
     if (!req.body) {
-      return res
-        .status(HTTP_STATUS_CODE.BAD_REQUEST)
-        .json(embraceResponse({ error: 'Request body is empty or not attached!' }));
+      return wrapRes(res, HTTP_STATUS_CODE.BAD_REQUEST, { error: 'Request body is empty or not attached!' });
     } else if (!req.body.login) {
-      return res
-        .status(HTTP_STATUS_CODE.BAD_REQUEST)
-        .json(embraceResponse({ error: 'User login is empty or not attached!' }));
+      return wrapRes(res, HTTP_STATUS_CODE.BAD_REQUEST, { error: 'User login is empty or not attached!' });
     }
 
     const user = (await getFromDB({ login: req.body.login }, 'User')) as IUser;
 
     if (!user) {
-      return res.status(HTTP_STATUS_CODE.UNAUTHORIZED).json(embraceResponse({ error: 'Invalid credentials!' }));
+      return wrapRes(res, HTTP_STATUS_CODE.UNAUTHORIZED, { error: 'Invalid credentials!' });
     }
 
     const isPasswordMatch = await user.matchPassword(req.body.password);
 
     if (!isPasswordMatch) {
-      return res.status(HTTP_STATUS_CODE.UNAUTHORIZED).json(embraceResponse({ error: 'Invalid credentials!' }));
+      return wrapRes(res, HTTP_STATUS_CODE.UNAUTHORIZED, { error: 'Invalid credentials!' });
     }
 
     if (!user.isConfirmed) {
-      return res
-        .status(HTTP_STATUS_CODE.UNAUTHORIZED)
-        .json(embraceResponse({ error: 'User registration is not confirmed!' }));
+      return wrapRes(res, HTTP_STATUS_CODE.UNAUTHORIZED, { error: 'User registration is not confirmed!' });
     }
 
     const authToken = await user.generateAuthToken();
 
-    return res.status(HTTP_STATUS_CODE.OK).json(
-      embraceResponse({
-        payload: normalizePayloadType(user),
-        authToken,
-      })
-    );
+    return wrapRes(res, HTTP_STATUS_CODE.OK, {
+      payload: user as Record<keyof IUser, IUser[keyof IUser]>,
+      authToken,
+    });
   } catch (exception) {
     return next(exception);
   }
@@ -382,21 +358,19 @@ async function changePassword(req: Request & { user: IUser }, res: Response, nex
     logger.log('(changePassword) req.body:', req.body);
 
     if (!req.body || !req.body.password || !req.body.newPassword) {
-      return res
-        .status(HTTP_STATUS_CODE.BAD_REQUEST)
-        .json(embraceResponse({ error: 'Request body is empty or not attached!' }));
+      return wrapRes(res, HTTP_STATUS_CODE.BAD_REQUEST, { error: 'Request body is empty or not attached!' });
     }
 
     const isPasswordMatch = await req.user.matchPassword(req.body.password);
 
     if (!isPasswordMatch) {
-      return res.status(HTTP_STATUS_CODE.UNAUTHORIZED).json(embraceResponse({ error: 'Invalid credentials!' }));
+      return wrapRes(res, HTTP_STATUS_CODE.UNAUTHORIZED, { error: 'Invalid credentials!' });
     }
 
     req.user.password = await hashPassword(req.body.newPassword);
     req.user.save();
 
-    return res.sendStatus(HTTP_STATUS_CODE.NO_CONTENT);
+    return wrapRes(res, HTTP_STATUS_CODE.NO_CONTENT);
   } catch (exception) {
     return next(exception);
   }
@@ -407,9 +381,7 @@ async function resetPassword(req: Request, res: Response, next: NextFunction) {
 
   try {
     if (!req.body.email) {
-      return res
-        .status(HTTP_STATUS_CODE.BAD_REQUEST)
-        .json(embraceResponse({ error: 'Email is empty or not attached!' }));
+      return wrapRes(res, HTTP_STATUS_CODE.BAD_REQUEST, { error: 'Email is empty or not attached!' });
     }
 
     const userToResetPassword = (await getFromDB(
@@ -428,7 +400,7 @@ async function resetPassword(req: Request, res: Response, next: NextFunction) {
         res,
       });
     } else {
-      return res.status(HTTP_STATUS_CODE.NOT_FOUND).json({ error: 'User not found!' });
+      return wrapRes(res, HTTP_STATUS_CODE.NOT_FOUND, { error: 'User not found!' });
     }
   } catch (exception) {
     return next(exception);
@@ -441,13 +413,9 @@ async function resendResetPassword(req: Request, res: Response, next: NextFuncti
 
   try {
     if (!req.body) {
-      return res
-        .status(HTTP_STATUS_CODE.BAD_REQUEST)
-        .json(embraceResponse({ error: 'Request body is empty or not attached!' }));
+      return wrapRes(res, HTTP_STATUS_CODE.BAD_REQUEST, { error: 'Request body is empty or not attached!' });
     } else if (!req.body.email) {
-      return res
-        .status(HTTP_STATUS_CODE.BAD_REQUEST)
-        .json(embraceResponse(embraceResponse({ error: 'Email prop is empty or not attached!' })));
+      return wrapRes(res, HTTP_STATUS_CODE.BAD_REQUEST, { error: 'Email prop is empty or not attached!' });
     }
 
     const userToResendResetPassword = (await getFromDB(
@@ -465,7 +433,7 @@ async function resendResetPassword(req: Request, res: Response, next: NextFuncti
         res,
       });
     } else {
-      return res.status(HTTP_STATUS_CODE.NOT_FOUND).json(embraceResponse({ error: 'User not found!' }));
+      return wrapRes(res, HTTP_STATUS_CODE.NOT_FOUND, { error: 'User not found!' });
     }
   } catch (exception) {
     return next(exception);
@@ -482,7 +450,7 @@ async function logOutUser(req: Request & { user: IUser; token: string }, res: Re
 
     await req.user.save();
 
-    return res.status(HTTP_STATUS_CODE.OK).json(embraceResponse({ authToken: null }));
+    return wrapRes(res, HTTP_STATUS_CODE.OK, { authToken: null });
   } catch (exception) {
     return next(exception);
   }
@@ -496,9 +464,9 @@ async function logOutUserFromSessions(
   try {
     if (req.body.preseveCurrentSession) {
       if ((req.user.tokens.auth as string[]).length === 1) {
-        return res
-          .status(HTTP_STATUS_CODE.NOT_FOUND)
-          .json(embraceResponse({ error: 'Current session is the only one, so there is no other sessions to end!' }));
+        return wrapRes(res, HTTP_STATUS_CODE.NOT_FOUND, {
+          error: 'Current session is the only one, so there is no other sessions to end!',
+        });
       }
 
       req.user.tokens.auth = (req.user.tokens.auth as string[]).filter((authToken) => authToken === req.token);
@@ -508,7 +476,7 @@ async function logOutUserFromSessions(
 
     await req.user.save();
 
-    return res.status(HTTP_STATUS_CODE.OK).json(embraceResponse({ authToken: null }));
+    return wrapRes(res, HTTP_STATUS_CODE.OK, { authToken: null });
   } catch (exception) {
     return next(exception);
   }
@@ -519,18 +487,16 @@ async function getUser(req: Request, res: Response, next: NextFunction) {
     logger.log('[GET] /:id', req.params.id);
 
     if (!req.params.id) {
-      return res
-        .status(HTTP_STATUS_CODE.BAD_REQUEST)
-        .json(embraceResponse({ error: 'User id is empty or not attached!' }));
+      return wrapRes(res, HTTP_STATUS_CODE.BAD_REQUEST, { error: 'User id is empty or not attached!' });
     }
 
     const user: IUser = await getFromDB(req.params.id, 'User');
 
     if (!user) {
-      return res.status(HTTP_STATUS_CODE.NOT_FOUND).json(embraceResponse({ error: `User not found!` }));
+      return wrapRes(res, HTTP_STATUS_CODE.NOT_FOUND, { error: `User not found!` });
     }
 
-    return res.status(HTTP_STATUS_CODE.OK).json(embraceResponse({ payload: normalizePayloadType(user) }));
+    return wrapRes(res, HTTP_STATUS_CODE.OK, { payload: user as Record<keyof IUser, IUser[keyof IUser]> });
   } catch (exception) {
     return next(exception);
   }
@@ -541,22 +507,20 @@ async function addProductToObserved(req: Request & { user: IUser }, res: Respons
     logger.log('(addProductToObserved) req.body:', req.body);
 
     if (!req.body || !req.body.productId) {
-      return res
-        .status(HTTP_STATUS_CODE.BAD_REQUEST)
-        .json(embraceResponse({ error: 'Request body or `productId` param are empty or not attached!' }));
+      return wrapRes(res, HTTP_STATUS_CODE.BAD_REQUEST, {
+        error: 'Request body or `productId` param are empty or not attached!',
+      });
     }
 
     const observationAdditionError = req.user.addProductToObserved(req.body.productId);
 
     if (observationAdditionError) {
-      return res.status(HTTP_STATUS_CODE.CONFLICT).json(embraceResponse({ error: observationAdditionError }));
+      return wrapRes(res, HTTP_STATUS_CODE.CONFLICT, { error: observationAdditionError });
     }
 
     await req.user.save();
 
-    return res
-      .status(HTTP_STATUS_CODE.OK)
-      .json(embraceResponse({ payload: req.user.observedProductsIDs || ([] as unknown[]) }));
+    return wrapRes(res, HTTP_STATUS_CODE.OK, { payload: req.user.observedProductsIDs || ([] as unknown[]) });
   } catch (exception) {
     return next(exception);
   }
@@ -567,22 +531,20 @@ async function removeProductFromObserved(req: Request & { user: IUser }, res: Re
     logger.log('(removeProductFromObserved) req.params:', req.params);
 
     if (!req.params || !req.params.productId) {
-      return res
-        .status(HTTP_STATUS_CODE.BAD_REQUEST)
-        .json(embraceResponse({ error: 'Request params or `productId` param are empty or not attached!' }));
+      return wrapRes(res, HTTP_STATUS_CODE.BAD_REQUEST, {
+        error: 'Request params or `productId` param are empty or not attached!',
+      });
     }
 
     const observationRemovalError = req.user.removeProductFromObserved(req.params.productId);
 
     if (observationRemovalError) {
-      return res.status(HTTP_STATUS_CODE.NOT_FOUND).json(embraceResponse({ error: observationRemovalError }));
+      return wrapRes(res, HTTP_STATUS_CODE.NOT_FOUND, { error: observationRemovalError });
     }
 
     await req.user.save();
 
-    return res
-      .status(HTTP_STATUS_CODE.OK)
-      .json(embraceResponse({ payload: req.user.observedProductsIDs || ([] as unknown[]) }));
+    return wrapRes(res, HTTP_STATUS_CODE.OK, { payload: req.user.observedProductsIDs || ([] as unknown[]) });
   } catch (exception) {
     return next(exception);
   }
@@ -593,14 +555,12 @@ async function removeAllProductsFromObserved(req: Request & { user: IUser }, res
     const observationsRemovalError = req.user.removeAllProductsFromObserved();
 
     if (observationsRemovalError) {
-      return res.status(HTTP_STATUS_CODE.NOT_FOUND).json(embraceResponse({ error: observationsRemovalError }));
+      return wrapRes(res, HTTP_STATUS_CODE.NOT_FOUND, { error: observationsRemovalError });
     }
 
     await req.user.save();
 
-    return res
-      .status(HTTP_STATUS_CODE.OK)
-      .json(embraceResponse({ payload: req.user.observedProductsIDs || ([] as unknown[]) }));
+    return wrapRes(res, HTTP_STATUS_CODE.OK, { payload: req.user.observedProductsIDs || ([] as unknown[]) });
   } catch (exception) {
     return next(exception);
   }
@@ -619,7 +579,7 @@ async function getObservedProducts(
         return emptyObservedProductsResponse;
       }
 
-      return res.status(HTTP_STATUS_CODE.OK).json(embraceResponse({ payload: emptyObservedProductsResponse }));
+      return wrapRes(res, HTTP_STATUS_CODE.OK, { payload: emptyObservedProductsResponse });
     }
 
     const observedProducts = await getFromDB({ _id: req.user.observedProductsIDs }, 'Product');
@@ -628,7 +588,7 @@ async function getObservedProducts(
       return observedProducts;
     }
 
-    return res.status(HTTP_STATUS_CODE.OK).json(embraceResponse({ payload: observedProducts }));
+    return wrapRes(res, HTTP_STATUS_CODE.OK, { payload: observedProducts });
   } catch (exception) {
     return next(exception);
   }


### PR DESCRIPTION
Partially related to #22.

- frontend routing paths are now contextually grouped and exposed as constant
- middleware response wrapper is extended to not only check whether data passed to [`.json(..)` method](https://expressjs.com/en/4x/api.html#res.json) conforms the interface, but also if it's consistent with certain group of HTTP status codes (like 'successful' or 'client error'). Wrapper also has overloads, which let sending just the HTTP status without any data (like in [`204` case](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204))