### PR TITLE
Adjusted entry page and routing

### DIFF
--- a/src/database/models/_product.ts
+++ b/src/database/models/_product.ts
@@ -62,6 +62,14 @@ const productSchema = new Schema<IProduct>({
   url: {
     type: String,
     required: true,
+    set(value: string) {
+      if (value.includes('/')) {
+        logger.log('Doing percentage encoding for all forward slashes for product url:', value);
+        return value.replace(/\//g, '%2F');
+      }
+
+      return value;
+    },
   },
   category: {
     type: String,

--- a/src/database/models/_user.ts
+++ b/src/database/models/_user.ts
@@ -99,6 +99,7 @@ userSchema.methods.toJSON = function (): TUserPublic {
   }
 
   return {
+    _id: user._id,
     login: user.login,
     email: user.email,
     observedProductsIDs: user.observedProductsIDs || [],
@@ -235,6 +236,7 @@ export type TUserModel = typeof UserModel;
 
 export type TUserPublic = Pick<IUser, 'login' | 'email' | 'observedProductsIDs'> & {
   accountType: NonNullable<IUser['accountType']>['roleName'];
+  _id: Schema.Types.ObjectId;
 };
 
 export type TUserToPopulate = Pick<IUser, 'login' | 'password' | 'email' | 'isConfirmed'> & {

--- a/src/database/populate/populate.ts
+++ b/src/database/populate/populate.ts
@@ -109,18 +109,21 @@ const executeDBPopulation = async (shouldCleanupAll = false) => {
     logger.log(`Cleaning done. Removed: ${removedData}`);
   }
 
-  if (getScriptParamStringValue(PARAMS.JSON_FILE_PATH.USER_ROLES)) {
-    const userRolesSourceDataList = getSourceData<TUserRoleToPopulate>(CAPITALIZED_PLURAL_COLLECTION_NAMES.USER_ROLES);
+  const userRolesPath = getScriptParamStringValue(PARAMS.JSON_FILE_PATH.USER_ROLES);
+  if (userRolesPath) {
+    const userRolesSourceDataList = getSourceData<TUserRoleToPopulate>(userRolesPath);
     await populateUserRoles(userRolesSourceDataList);
   }
 
-  if (getScriptParamStringValue(PARAMS.JSON_FILE_PATH.USERS)) {
-    const usersSourceDataList = getSourceData<TUserToPopulate>(CAPITALIZED_PLURAL_COLLECTION_NAMES.USERS);
+  const usersPath = getScriptParamStringValue(PARAMS.JSON_FILE_PATH.USERS);
+  if (usersPath) {
+    const usersSourceDataList = getSourceData<TUserToPopulate>(usersPath);
     await populateUsers(usersSourceDataList);
   }
 
-  if (getScriptParamStringValue(PARAMS.JSON_FILE_PATH.PRODUCTS)) {
-    const productsSourceDataList = getSourceData<TProductToPopulate>(CAPITALIZED_PLURAL_COLLECTION_NAMES.PRODUCTS);
+  const productsPath = getScriptParamStringValue(PARAMS.JSON_FILE_PATH.PRODUCTS);
+  if (productsPath) {
+    const productsSourceDataList = getSourceData<TProductToPopulate>(productsPath);
     await populateProducts(productsSourceDataList);
     await updateRelatedProductsNames(productsSourceDataList);
   }
@@ -158,18 +161,13 @@ const executeDBPopulation = async (shouldCleanupAll = false) => {
 };
 
 if (getScriptParamStringValue(PARAMS.EXECUTED_FROM_CLI)) {
-  executeDBPopulation();
+  executeDBPopulation().then(() => {
+    logger.log('Exiting from populate.ts initiated via CLI...');
+    process.exit(0);
+  });
 }
 
-function getSourceData<T extends TDataToPopulate>(modelName: keyof typeof PARAMS.JSON_FILE_PATH): T[] {
-  const sourceDataPath = getScriptParamStringValue(PARAMS.JSON_FILE_PATH[modelName]);
-
-  if (!sourceDataPath) {
-    throw ReferenceError(
-      `Path to data for "${modelName}" was not provided! You must pass "${PARAMS.JSON_FILE_PATH[modelName]}" parameter.`
-    );
-  }
-
+function getSourceData<T extends TDataToPopulate>(sourceDataPath: string): T[] {
   logger.log('getSourceData() /sourceDataPath:', sourceDataPath);
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const sourceDataFiles = require(sourceDataPath);

--- a/src/database/utils/__mocks__/queryBuilder.ts
+++ b/src/database/utils/__mocks__/queryBuilder.ts
@@ -17,6 +17,9 @@ export const queryBuilder = (() => {
     getSearchByNameConfig: jest.fn(() => {
       throw getMockImplementationError('getSearchByNameConfig');
     }),
+    getSearchByUrlConfig: jest.fn(() => {
+      throw getMockImplementationError('getSearchByUrlConfig');
+    }),
     getFilters: jest.fn(() => {
       throw getMockImplementationError('getFilters');
     }),
@@ -48,6 +51,11 @@ export const queryBuilder = (() => {
     name: /test/,
   });
   _queryBuilder.getSearchByNameConfig._failedCall = () => null;
+
+  _queryBuilder.getSearchByUrlConfig._succeededCall = () => ({
+    name: /some-test-product/,
+  });
+  _queryBuilder.getSearchByUrlConfig._failedCall = () => null;
 
   _queryBuilder.getFilters._succeededCall = () => ({
     $and: [

--- a/src/database/utils/queryBuilder.ts
+++ b/src/database/utils/queryBuilder.ts
@@ -16,6 +16,14 @@ const getSearchByNameConfig = (reqQuery: TReqQuery) => {
   return { name: nameQuery };
 };
 
+const getSearchByUrlConfig = (reqQuery: TReqQuery) => {
+  if (!reqQuery.url) {
+    return null;
+  }
+
+  return { url: reqQuery.url };
+};
+
 const getPaginationConfig = (reqQuery: TReqQuery) => {
   if (!('page' in reqQuery) || !('limit' in reqQuery)) {
     return null;
@@ -158,6 +166,7 @@ export const queryBuilder = {
   getPaginationConfig,
   getIdListConfig,
   getNameListConfig,
+  getSearchByUrlConfig,
   getProductsWithChosenCategories,
   getFilters,
 };

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -7,6 +7,14 @@ import Main from './components/views/main';
 import Footer from './components/views/footer';
 import { RWDLayoutProvider } from './contexts/rwd-layout';
 import { MUIThemeProvider } from './contexts/mui-theme';
+import userSessionService from '@frontend/features/userSessionService';
+
+/*
+  TODO: [UX] save user session to storage when page is unloaded (like by reloading or closing it).
+  It may be done via window's 'beforeunload' event, but it's better to use Page Lifecycle (API)
+  https://developers.google.com/web/updates/2018/07/page-lifecycle-api#observing-page-lifecycle-states-in-code
+*/
+userSessionService.restoreSession();
 
 const App = () => (
   <StrictMode>

--- a/src/frontend/assets/styles/main.scss
+++ b/src/frontend/assets/styles/main.scss
@@ -6,7 +6,7 @@
 @import '_mixins';
 @import '_helpers';
 @import 'views/app';
-@import 'views/shop';
+@import 'views/home';
 @import 'views/nav';
 @import 'views/categoriesTree';
 @import 'views/productList';

--- a/src/frontend/assets/styles/main.scss
+++ b/src/frontend/assets/styles/main.scss
@@ -5,6 +5,7 @@
 @import '_var';
 @import '_mixins';
 @import '_helpers';
+@import 'views/shared';
 @import 'views/app';
 @import 'views/home';
 @import 'views/nav';

--- a/src/frontend/assets/styles/views/cart.scss
+++ b/src/frontend/assets/styles/views/cart.scss
@@ -1,3 +1,11 @@
+.cart-toggler-btn {
+  text-transform: none;
+
+  &--not-mobile {
+    padding: 0;
+  }
+}
+
 .cart {
   &__header {
     position: relative;

--- a/src/frontend/assets/styles/views/home.scss
+++ b/src/frontend/assets/styles/views/home.scss
@@ -1,0 +1,32 @@
+.entry-views-chooser {
+    &__list {
+        justify-content: space-around;
+    }
+
+    &__list-item {
+        width: 10rem;
+        height: 7.5rem;
+        justify-content: center;
+        border: 1px solid;
+        border-radius: 0.5rem;
+        padding: 0;
+
+        &:hover {
+            background: #3f51b5;
+        }
+
+        a {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: space-evenly;
+            width: 100%;
+            height: 100%;
+            padding: 1rem;
+
+            &:hover {
+                color: white;
+            }
+        }
+    }
+}

--- a/src/frontend/assets/styles/views/home.scss
+++ b/src/frontend/assets/styles/views/home.scss
@@ -1,32 +1,29 @@
-.entry-views-chooser {
-    &__list {
-        justify-content: space-around;
+.home, .home-section {
+    align-items: stretch;
+}
+
+.home-section {
+    &__product-list {
+        display: flex;
+        align-items: center;
+        --product-card-width: 200px;
+
+        [data-compare-btn-scroll-dir] button {
+            width: 2rem;
+        }
+
+        [data-scrollable-parent] {
+            --scrollable-min-height: 8rem;
+        }
+
+        ul {
+            display: flex;
+            gap: 1rem;
+        }
     }
 
-    &__list-item {
-        width: 10rem;
-        height: 7.5rem;
-        justify-content: center;
-        border: 1px solid;
-        border-radius: 0.5rem;
-        padding: 0;
-
-        &:hover {
-            background: #3f51b5;
-        }
-
-        a {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: space-evenly;
-            width: 100%;
-            height: 100%;
-            padding: 1rem;
-
-            &:hover {
-                color: white;
-            }
-        }
+    &__link-to-see-all {
+        text-align: center;
+        text-transform: uppercase;
     }
 }

--- a/src/frontend/assets/styles/views/nav.scss
+++ b/src/frontend/assets/styles/views/nav.scss
@@ -8,19 +8,45 @@
     margin-inline: auto;
 }
 
+@mixin navItem {
+    font-size: 1.8rem;
+}
+
+@mixin navDeepItem {
+    padding: 0.25rem 1rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.8rem;
+
+    .MuiSvgIcon-root {
+        font-size: 1.8rem;
+    }
+}
+
 .nav-menu__links {
     display: flex;
     flex-direction: column;
     justify-content: space-evenly;
-    margin-inline: 1rem;
+    align-items: center;
 
     li {
         padding: 0;
         margin-block: 0.25rem;
+        @include navItem;
 
         a {
-            padding: 0.5rem 1rem;
+           @include navDeepItem;
         }
+    }
+}
+
+.cart-toggler-btn {
+    @include navItem;
+    
+    &--not-mobile .MuiButton-label {
+        @include navDeepItem;
     }
 }
 

--- a/src/frontend/assets/styles/views/productDetails.scss
+++ b/src/frontend/assets/styles/views/productDetails.scss
@@ -5,7 +5,7 @@
         display: grid;
         grid-template-areas:
             "category"
-            "action-buttons"
+            "action-elements"
             "image"
             "name"
             "rating"
@@ -18,13 +18,13 @@
         grid-area: category;
     }
 
-    &__header-action-btns {
-        grid-area: action-buttons;
+    &__header-action-elements {
+        grid-area: action-elements;
         display: flex;
         justify-content: center;
         align-items: center;
         flex-wrap: wrap;
-        gap: 0.25rem;
+        gap: 0.5rem;
     }
 
     &__header-image {
@@ -138,7 +138,7 @@
     .product-details {
         &__header {
             grid-template-areas:
-                "category action-buttons action-buttons action-buttons"
+                "category action-elements action-elements action-elements"
                 "image image name name"
                 "image image rating rating"
                 "image image price price"

--- a/src/frontend/assets/styles/views/shared.scss
+++ b/src/frontend/assets/styles/views/shared.scss
@@ -1,0 +1,5 @@
+.navigate-to-modify-product {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+}

--- a/src/frontend/assets/styles/views/shop.scss
+++ b/src/frontend/assets/styles/views/shop.scss
@@ -1,3 +1,0 @@
-.shop-container {
-
-}

--- a/src/frontend/components/pages/_routes.ts
+++ b/src/frontend/components/pages/_routes.ts
@@ -3,28 +3,59 @@ import type { TStoreService } from '@frontend/features/storeService';
 const ROUTE_GROUPS = Object.freeze({
   ROOT: '/',
   PAGES: '/pages',
-  get SHOP() {
-    return `${this.PAGES}/shop`;
+  get PRODUCTS() {
+    return `${this.PAGES}/products`;
+  },
+  get ACCOUNT() {
+    return `${this.PAGES}/account`;
   },
 });
 
 export const ROUTES = Object.freeze({
   ROOT: ROUTE_GROUPS.ROOT,
   PAGES: ROUTE_GROUPS.PAGES,
-  SHOP: ROUTE_GROUPS.SHOP,
-  PRODUCT: `${ROUTE_GROUPS.SHOP}/product`,
   REGISTER: `${ROUTE_GROUPS.PAGES}/register`,
   CONFIRM_REGISTRATION: `${ROUTE_GROUPS.PAGES}/confirm-registration`,
   LOG_IN: `${ROUTE_GROUPS.PAGES}/log-in`,
+  NOT_FOUND: `${ROUTE_GROUPS.PAGES}/not-found`,
   NOT_LOGGED_IN: `${ROUTE_GROUPS.PAGES}/not-logged-in`,
   NOT_AUTHORIZED: `${ROUTE_GROUPS.PAGES}/not-authorized`,
   RESET_PASSWORD: `${ROUTE_GROUPS.PAGES}/reset-password`,
   SET_NEW_PASSWORD: `${ROUTE_GROUPS.PAGES}/set-new-password`,
-  ACCOUNT: `${ROUTE_GROUPS.PAGES}/account`,
-  COMPARE: `${ROUTE_GROUPS.SHOP}/compare`,
-  ADD_NEW_PRODUCT: `${ROUTE_GROUPS.SHOP}/add-new-product`,
-  MODIFY_PRODUCT: `${ROUTE_GROUPS.SHOP}/modify-product`,
-  ORDER: `${ROUTE_GROUPS.SHOP}/order`,
+  // product related
+  PRODUCTS: ROUTE_GROUPS.PRODUCTS,
+  PRODUCTS__PRODUCT: `${ROUTE_GROUPS.PRODUCTS}/:productName`,
+  PRODUCTS__COMPARE: `${ROUTE_GROUPS.PRODUCTS}/compare`,
+  PRODUCTS__ADD_NEW_PRODUCT: `${ROUTE_GROUPS.PRODUCTS}/add-new-product`,
+  get PRODUCTS__MODIFY_PRODUCT() {
+    return `${this.PRODUCTS__PRODUCT}/modify-product`;
+  },
+  PRODUCTS__ORDER: `${ROUTE_GROUPS.PRODUCTS}/order`,
+  // account related
+  ACCOUNT: ROUTE_GROUPS.ACCOUNT,
+  get ACCOUNT__USER_PROFILE() {
+    return `${this.ACCOUNT}/user-profile`;
+  },
+  get ACCOUNT__SECURITY() {
+    return `${this.ACCOUNT}/security`;
+  },
+  get ACCOUNT__OBSERVED_PRODUCTS() {
+    return `${this.ACCOUNT}/observed-products`;
+  },
+  get ACCOUNT__ORDERS() {
+    return `${this.ACCOUNT}/orders`;
+  },
+});
+
+export const routeHelpers = Object.freeze({
+  createModifyProductUrl(productName: string) {
+    return ROUTES.PRODUCTS__MODIFY_PRODUCT.replace(/:\w+/, productName);
+  },
+  extractProductUrlFromPathname(pathname: string) {
+    const productUrlRegExpSource = ROUTES.PRODUCTS__PRODUCT.replace(/:.*?(?=\/|$)/, '(?<productUrl>[^/]*)');
+
+    return (pathname.match(new RegExp(productUrlRegExpSource)) || { groups: { productUrl: '' } }).groups!.productUrl;
+  },
 });
 
 export const useRoutesGuards = (storeService: TStoreService) => {

--- a/src/frontend/components/pages/home.jsx
+++ b/src/frontend/components/pages/home.jsx
@@ -1,5 +1,80 @@
 import React from 'react';
+import { Redirect } from 'react-router-dom';
+import { observer } from 'mobx-react-lite';
 
-export default function Home() {
-  return <h2>Home!!!</h2>;
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListIcon from '@material-ui/icons/List';
+import AddToListIcon from '@material-ui/icons/PlaylistAdd';
+
+import { PEVHeading, PEVLink } from '@frontend/components/utils/pevElements';
+import { ROUTES, useRoutesGuards } from '@frontend/components/pages/_routes';
+import storeService from '@frontend/features/storeService';
+
+const translations = Object.freeze({
+  heading: 'Where do you want to go?',
+  soldProducts: 'See products sold',
+  addNewProduct: 'Add new product',
+});
+
+function EntryViewsChooser({ views }) {
+  return (
+    <section className="entry-views-chooser pev-fixed-container">
+      <PEVHeading level={2} className="pev-centered-padded-text">
+        {translations.heading}
+      </PEVHeading>
+      <List className="entry-views-chooser__list pev-flex">
+        {views.map(({ subPageUrl, translation, icon, dataCyValue }) => (
+          <ListItem className="entry-views-chooser__list-item" key={translation}>
+            <PEVLink to={subPageUrl} data-cy={`link:${dataCyValue}`}>
+              {icon}
+              {translation}
+            </PEVLink>
+          </ListItem>
+        ))}
+      </List>
+    </section>
+  );
 }
+
+const generateHomeView = (routesGuards, justUrl = false) => {
+  switch (true) {
+    case routesGuards.isSeller(): {
+      if (justUrl) {
+        return ROUTES.ROOT;
+      }
+
+      const views = [
+        {
+          subPageUrl: ROUTES.SHOP,
+          translation: translations.soldProducts,
+          icon: <ListIcon fontSize="large" />,
+          dataCyValue: 'shop',
+        },
+        {
+          subPageUrl: ROUTES.ADD_NEW_PRODUCT,
+          translation: translations.addNewProduct,
+          icon: <AddToListIcon fontSize="large" />,
+          dataCyValue: 'add-new-product',
+        },
+      ];
+
+      return <EntryViewsChooser views={views} />;
+    }
+    default: {
+      if (justUrl) {
+        return ROUTES.SHOP;
+      }
+
+      return <Redirect to={ROUTES.SHOP} />;
+    }
+  }
+};
+
+export const getUrlToHome = (routesGuards) => generateHomeView(routesGuards, true);
+
+export default observer(function Home() {
+  const routesGuards = useRoutesGuards(storeService);
+
+  return generateHomeView(routesGuards);
+});

--- a/src/frontend/components/pages/home.jsx
+++ b/src/frontend/components/pages/home.jsx
@@ -1,80 +1,88 @@
-import React from 'react';
-import { Redirect } from 'react-router-dom';
-import { observer } from 'mobx-react-lite';
+import React, { useState, useEffect } from 'react';
 
-import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
-import ListIcon from '@material-ui/icons/List';
-import AddToListIcon from '@material-ui/icons/PlaylistAdd';
+import Divider from '@material-ui/core/Divider';
 
 import { PEVHeading, PEVLink } from '@frontend/components/utils/pevElements';
-import { ROUTES, useRoutesGuards } from '@frontend/components/pages/_routes';
-import storeService from '@frontend/features/storeService';
+import Scroller from '@frontend/components/utils/scroller';
+import { ProductSpecificDetail } from '@frontend/components/views/productDetails';
+import httpService from '@frontend/features/httpService';
 
 const translations = Object.freeze({
-  heading: 'Where do you want to go?',
-  soldProducts: 'See products sold',
-  addNewProduct: 'Add new product',
+  bestSellersHeading: 'Best sellers:',
+  topRatedHeading: 'Top rated:',
+  recentlyAddedHeading: 'Recently added:',
+  recentlyViewedHeading: 'Recently viewed by you:',
+  seeAll: 'see all',
 });
 
-function EntryViewsChooser({ views }) {
+export default function Home() {
+  const [products, setProducts] = useState([]);
+  const sections = [
+    {
+      heading: translations.bestSellersHeading,
+      productList: <p>TODO: fetch the data</p>,
+      seeAllUrl: '#',
+    },
+    {
+      heading: translations.topRatedHeading,
+      productList: <p>TODO: fetch the data</p>,
+      seeAllUrl: '#',
+    },
+    {
+      heading: translations.recentlyAddedHeading,
+      productList: (
+        <ProductSpecificDetail
+          detailName="relatedProducts"
+          detailValue={products}
+          extras={{
+            disableListItemGutters: true,
+          }}
+        />
+      ),
+      seeAllUrl: '#',
+    },
+    {
+      heading: translations.recentlyViewedHeading,
+      productList: <p>TODO: fetch the data</p>,
+      seeAllUrl: '#',
+    },
+  ];
+
+  useEffect(() => {
+    const pagination = { pageNumber: 1, productsPerPage: 5 };
+
+    httpService.getProducts({ pagination }).then((res) => {
+      if (res.__EXCEPTION_ALREADY_HANDLED) {
+        return;
+      }
+
+      setProducts(res.productsList);
+    });
+  }, []);
+
   return (
-    <section className="entry-views-chooser pev-fixed-container">
-      <PEVHeading level={2} className="pev-centered-padded-text">
-        {translations.heading}
-      </PEVHeading>
-      <List className="entry-views-chooser__list pev-flex">
-        {views.map(({ subPageUrl, translation, icon, dataCyValue }) => (
-          <ListItem className="entry-views-chooser__list-item" key={translation}>
-            <PEVLink to={subPageUrl} data-cy={`link:${dataCyValue}`}>
-              {icon}
-              {translation}
-            </PEVLink>
-          </ListItem>
-        ))}
-      </List>
-    </section>
+    <article className="home pev-fixed-container pev-flex pev-flex--columned">
+      {sections.map(({ heading, productList, seeAllUrl }) => (
+        <section className="home-section pev-flex pev-flex--columned" key={heading}>
+          <PEVHeading level={2}>{heading}</PEVHeading>
+
+          <div className="home-section__product-list">
+            <Scroller
+              scrollerBaseValueMeta={{
+                selector: '.home-section__product-list',
+                varName: '--product-card-width',
+              }}
+              render={({ ScrollerHookingParent }) => <ScrollerHookingParent>{productList}</ScrollerHookingParent>}
+            />
+          </div>
+
+          <Divider />
+
+          <PEVLink to={seeAllUrl} color="primary" className="home-section__link-to-see-all">
+            {translations.seeAll}
+          </PEVLink>
+        </section>
+      ))}
+    </article>
   );
 }
-
-const generateHomeView = (routesGuards, justUrl = false) => {
-  switch (true) {
-    case routesGuards.isSeller(): {
-      if (justUrl) {
-        return ROUTES.ROOT;
-      }
-
-      const views = [
-        {
-          subPageUrl: ROUTES.SHOP,
-          translation: translations.soldProducts,
-          icon: <ListIcon fontSize="large" />,
-          dataCyValue: 'shop',
-        },
-        {
-          subPageUrl: ROUTES.ADD_NEW_PRODUCT,
-          translation: translations.addNewProduct,
-          icon: <AddToListIcon fontSize="large" />,
-          dataCyValue: 'add-new-product',
-        },
-      ];
-
-      return <EntryViewsChooser views={views} />;
-    }
-    default: {
-      if (justUrl) {
-        return ROUTES.SHOP;
-      }
-
-      return <Redirect to={ROUTES.SHOP} />;
-    }
-  }
-};
-
-export const getUrlToHome = (routesGuards) => generateHomeView(routesGuards, true);
-
-export default observer(function Home() {
-  const routesGuards = useRoutesGuards(storeService);
-
-  return generateHomeView(routesGuards);
-});

--- a/src/frontend/components/pages/logIn.jsx
+++ b/src/frontend/components/pages/logIn.jsx
@@ -41,7 +41,7 @@ export default function LogIn() {
         TODO: [UX] redirect to the page where user was before logging in 
         OR just close/fold the form, if it is presented as a aside/sticky panel
       */
-      history.push(ROUTES.ROOT);
+      history.push(ROUTES.ACCOUNT__ORDERS);
     });
   };
 

--- a/src/frontend/components/pages/notFound.jsx
+++ b/src/frontend/components/pages/notFound.jsx
@@ -1,7 +1,24 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import { PEVParagraph } from '@frontend/components/utils/pevElements';
+
 const translations = Object.freeze({
-  notFoundHeader: 'Page not found!',
+  header: 'Page not found!',
+  createCustomHeader(label, url) {
+    if (label && url) {
+      return (
+        <PEVParagraph>
+          Page for {label} with url <b>{url}</b> not found!
+        </PEVParagraph>
+      );
+    }
+
+    return '';
+  },
 });
 
 export default function NotFound() {
-  return translations.notFoundHeader;
+  const { state } = useLocation();
+
+  return translations.createCustomHeader(state.label, state.url) || translations.header;
 }

--- a/src/frontend/components/pages/products.jsx
+++ b/src/frontend/components/pages/products.jsx
@@ -28,15 +28,11 @@ function Products() {
       <Route path={ROUTES.PRODUCTS__MODIFY_PRODUCT}>
         {routesGuards.isSeller() ? <ModifyProduct /> : <Redirect to={ROUTES.NOT_AUTHORIZED} />}
       </Route>
-      <Route path={ROUTES.PRODUCTS__PRODUCT}>
-        <ProductDetails />
-      </Route>
       <Route path={ROUTES.PRODUCTS__ORDER}>
         {routesGuards.isClient() ? <Order /> : <Redirect to={ROUTES.NOT_AUTHORIZED} />}
       </Route>
-
-      <Route>
-        <NotFound />
+      <Route path={ROUTES.PRODUCTS__PRODUCT}>
+        <ProductDetails />
       </Route>
     </Switch>
   );

--- a/src/frontend/components/pages/products.jsx
+++ b/src/frontend/components/pages/products.jsx
@@ -11,27 +11,29 @@ import ProductComparison from './productComparison';
 import Order from './order';
 import NotFound from './notFound';
 
-function Shop() {
+function Products() {
   const routesGuards = useRoutesGuards(storeService);
 
   return (
     <Switch>
-      <Route path={ROUTES.SHOP} exact>
+      <Route path={ROUTES.PRODUCTS} exact>
         <ProductList />
       </Route>
-      <Route path={`${ROUTES.PRODUCT}/:productName`}>
-        <ProductDetails />
-      </Route>
-      <Route path={ROUTES.COMPARE}>
+      <Route path={ROUTES.PRODUCTS__COMPARE}>
         <ProductComparison />
       </Route>
-      <Route path={ROUTES.ADD_NEW_PRODUCT}>
+      <Route path={ROUTES.PRODUCTS__ADD_NEW_PRODUCT}>
         {routesGuards.isSeller() ? <NewProduct /> : <Redirect to={ROUTES.NOT_AUTHORIZED} />}
       </Route>
-      <Route path={ROUTES.MODIFY_PRODUCT}>
+      <Route path={ROUTES.PRODUCTS__MODIFY_PRODUCT}>
         {routesGuards.isSeller() ? <ModifyProduct /> : <Redirect to={ROUTES.NOT_AUTHORIZED} />}
       </Route>
-      <Route path={ROUTES.ORDER}>{routesGuards.isClient() ? <Order /> : <Redirect to={ROUTES.NOT_AUTHORIZED} />}</Route>
+      <Route path={ROUTES.PRODUCTS__PRODUCT}>
+        <ProductDetails />
+      </Route>
+      <Route path={ROUTES.PRODUCTS__ORDER}>
+        {routesGuards.isClient() ? <Order /> : <Redirect to={ROUTES.NOT_AUTHORIZED} />}
+      </Route>
 
       <Route>
         <NotFound />
@@ -40,4 +42,4 @@ function Shop() {
   );
 }
 
-export default memo(observer(Shop));
+export default memo(observer(Products));

--- a/src/frontend/components/pages/shop.jsx
+++ b/src/frontend/components/pages/shop.jsx
@@ -1,8 +1,7 @@
-import React, { memo /*, useState*/ } from 'react';
+import React, { memo } from 'react';
 import { Route, Switch, Redirect } from 'react-router-dom';
 import { observer } from 'mobx-react-lite';
 
-// import CategoriesTree from '@frontend/components/views/categoriesTree';
 import { ROUTES, useRoutesGuards } from './_routes';
 import storeService from '@frontend/features/storeService';
 import ProductList from '@frontend/components/views/productList';
@@ -12,89 +11,32 @@ import ProductComparison from './productComparison';
 import Order from './order';
 import NotFound from './notFound';
 
-// const ShopMenuChooser = memo(function ShopMenuChooser(props) {
-//   return (
-//     <div className="shop-container">
-//       <ul>
-//         {props.viewsMap.map((view) => (
-//           <li key={`shop-${view.component.type.name}-menu`}>
-//             <button onClick={() => props.onMenuChooserClick(view.component)}>{view.translation}</button>
-//           </li>
-//         ))}
-//       </ul>
-//     </div>
-//   );
-// });
-
 function Shop() {
   const routesGuards = useRoutesGuards(storeService);
 
-  // const [chosenProductsView, setChosenProductsView] = useState('');
-  //
-  // const viewsMap = [
-  //   {
-  //     component: <CategoriesTree />,
-  //     translation: 'Kategorie',
-  //   },
-  //   {
-  //     component: <ProductList />,
-  //     translation: 'Lista',
-  //   },
-  // ];
-
-  // const setShopView = (chosenViewComponent) => {
-  //   setChosenProductsView(chosenViewComponent.type.name);
-  // };
-
-  // const showChooser = () => {
-  //   if (!chosenProductsView) {
-  //     return <ShopMenuChooser viewsMap={viewsMap} onMenuChooserClick={setShopView} />;
-  //   }
-  //
-  //   return '';
-  // };
-
-  // const showChosenProductsView = () => {
-  //   if (chosenProductsView) {
-  //     const matchedView = viewsMap.find(({ component }) => component.type.name === chosenProductsView);
-  //     return matchedView.component;
-  //   }
-  //
-  //   return '';
-  // };
-
   return (
-    <>
-      {/* <PEVHeading level={2}>Shop!!!</PEVHeading> */}
+    <Switch>
+      <Route path={ROUTES.SHOP} exact>
+        <ProductList />
+      </Route>
+      <Route path={`${ROUTES.PRODUCT}/:productName`}>
+        <ProductDetails />
+      </Route>
+      <Route path={ROUTES.COMPARE}>
+        <ProductComparison />
+      </Route>
+      <Route path={ROUTES.ADD_NEW_PRODUCT}>
+        {routesGuards.isSeller() ? <NewProduct /> : <Redirect to={ROUTES.NOT_AUTHORIZED} />}
+      </Route>
+      <Route path={ROUTES.MODIFY_PRODUCT}>
+        {routesGuards.isSeller() ? <ModifyProduct /> : <Redirect to={ROUTES.NOT_AUTHORIZED} />}
+      </Route>
+      <Route path={ROUTES.ORDER}>{routesGuards.isClient() ? <Order /> : <Redirect to={ROUTES.NOT_AUTHORIZED} />}</Route>
 
-      {/*{showChooser()}*/}
-
-      <Switch>
-        <Route path={ROUTES.SHOP} exact>
-          <ProductList />
-          {/*{showChosenProductsView()}*/}
-        </Route>
-        <Route path={`${ROUTES.PRODUCT}/:productName`}>
-          <ProductDetails />
-        </Route>
-        <Route path={ROUTES.COMPARE}>
-          <ProductComparison />
-        </Route>
-        <Route path={ROUTES.ADD_NEW_PRODUCT}>
-          {routesGuards.isSeller() ? <NewProduct /> : <Redirect to={ROUTES.NOT_AUTHORIZED} />}
-        </Route>
-        <Route path={ROUTES.MODIFY_PRODUCT}>
-          {routesGuards.isSeller() ? <ModifyProduct /> : <Redirect to={ROUTES.NOT_AUTHORIZED} />}
-        </Route>
-        <Route path={ROUTES.ORDER}>
-          {routesGuards.isClient() ? <Order /> : <Redirect to={ROUTES.NOT_AUTHORIZED} />}
-        </Route>
-
-        <Route>
-          <NotFound />
-        </Route>
-      </Switch>
-    </>
+      <Route>
+        <NotFound />
+      </Route>
+    </Switch>
   );
 }
 

--- a/src/frontend/components/shared.jsx
+++ b/src/frontend/components/shared.jsx
@@ -4,10 +4,10 @@ import { useHistory } from 'react-router-dom';
 import DeleteIcon from '@material-ui/icons/Delete';
 import EditIcon from '@material-ui/icons/Edit';
 
-import { PEVButton } from '@frontend/components/utils/pevElements';
+import { PEVButton, PEVLink } from '@frontend/components/utils/pevElements';
 import Popup, { POPUP_TYPES, getClosePopupBtn } from '@frontend/components/utils/popup';
 import httpService from '@frontend/features/httpService';
-import { ROUTES } from '@frontend/components/pages/_routes';
+import { ROUTES, routeHelpers } from '@frontend/components/pages/_routes';
 
 const translations = {
   editProduct: 'Edit',
@@ -18,7 +18,7 @@ const translations = {
   abortProductDeletion: 'No',
   productDeletionSuccess: 'Product successfully deleted!',
   productDeletionFailed: 'Deleting product failed :(',
-  goBackToShop: 'Go back to shop',
+  goBackToProducts: 'Go back to products',
   goTologIn: 'Log in',
 };
 
@@ -46,8 +46,8 @@ export function DeleteProductFeature({ productName }) {
                     message: translations.productDeletionSuccess,
                     buttons: [
                       {
-                        onClick: () => history.push(ROUTES.SHOP),
-                        text: translations.goBackToShop,
+                        onClick: () => history.push(ROUTES.PRODUCTS),
+                        text: translations.goBackToProducts,
                       },
                     ],
                   });
@@ -79,21 +79,15 @@ export function DeleteProductFeature({ productName }) {
   );
 }
 
-export function NavigateToModifyProduct({ productName }) {
-  const history = useHistory();
-
-  const handleNavigateToProductModify = () => {
-    history.push(ROUTES.MODIFY_PRODUCT, productName);
-  };
-
+export function NavigateToModifyProduct({ productData }) {
   return (
-    <PEVButton
-      size="small"
-      startIcon={<EditIcon />}
-      onClick={handleNavigateToProductModify}
+    <PEVLink
+      to={{ pathname: routeHelpers.createModifyProductUrl(productData.url), state: productData }}
+      className="navigate-to-modify-product"
       data-cy="button:product-details__edit-product"
     >
+      <EditIcon />
       {translations.editProduct}
-    </PEVButton>
+    </PEVLink>
   );
 }

--- a/src/frontend/components/utils/pevElements.jsx
+++ b/src/frontend/components/utils/pevElements.jsx
@@ -67,7 +67,7 @@ export const PEVIconButton = forwardRef(function PEVIconButton(props, ref) {
 
 export const PEVLink = forwardRef(function PEVLink({ children, ...restProps }, ref) {
   return (
-    <MUILink {...restProps} component={Link} color="inherit" ref={ref}>
+    <MUILink color="inherit" {...restProps} component={Link} ref={ref}>
       {children}
     </MUILink>
   );

--- a/src/frontend/components/views/cart.jsx
+++ b/src/frontend/components/views/cart.jsx
@@ -4,7 +4,7 @@ import { observer } from 'mobx-react-lite';
 
 import DeleteIcon from '@material-ui/icons/Delete';
 import CloseIcon from '@material-ui/icons/Close';
-import ShoppingCart from '@material-ui/icons/ShoppingCart';
+import ShoppingCartIcon from '@material-ui/icons/ShoppingCart';
 import AddShoppingCart from '@material-ui/icons/AddShoppingCart';
 import TableContainer from '@material-ui/core/TableContainer';
 import Drawer from '@material-ui/core/Drawer';
@@ -20,12 +20,13 @@ import storageService from '@frontend/features/storageService';
 import storeService from '@frontend/features/storeService';
 import { ROUTES, useRoutesGuards } from '@frontend/components/pages/_routes';
 import Popup, { POPUP_TYPES, getClosePopupBtn } from '@frontend/components/utils/popup';
+import { useRWDLayout } from '@frontend/contexts/rwd-layout';
+import classNames from 'classnames';
 
 const translations = {
   addToCartBtn: 'Add to cart',
   addingToCartAuthFailure: 'Adding product to cart is not available for your account type.',
   header: 'Cart',
-  cartLabel: 'cart',
   goBackLabel: 'go back',
   productNameHeader: 'Product',
   productCountHeader: 'Count',
@@ -90,6 +91,7 @@ export default observer(function Cart() {
   const [isCartOpen, setIsCartOpen] = useState(false);
   const history = useHistory();
   const isCartEmpty = storeService.userCartProducts?.length === 0;
+  const { isMobileLayout } = useRWDLayout();
 
   useEffect(() => {
     storeService.replaceUserCartState(storageService.userCart.get());
@@ -120,20 +122,23 @@ export default observer(function Cart() {
   };
 
   const handleCartSubmission = () => {
-    history.push(ROUTES.ORDER);
+    history.push(ROUTES.PRODUCTS__ORDER);
     handleCloseCart();
   };
 
   return (
     <>
-      <PEVIconButton
+      <PEVButton
+        className={classNames('cart-toggler-btn', { 'cart-toggler-btn--not-mobile': !isMobileLayout })}
         color="inherit"
+        variant="text"
         onClick={handleOpenCart}
-        a11y={translations.cartLabel}
+        a11y={translations.header}
         data-cy="button:toggle-cart"
       >
-        <ShoppingCart />
-      </PEVIconButton>
+        <ShoppingCartIcon fontSize="inherit" />
+        {!isMobileLayout && translations.header}
+      </PEVButton>
 
       <Drawer anchor="right" open={isCartOpen} onClose={handleCloseCart}>
         <section className="cart pev-flex pev-flex--columned" data-cy="container:cart">
@@ -148,7 +153,7 @@ export default observer(function Cart() {
           </header>
 
           <TableContainer className="cart__table">
-            <Table size="small" aria-label={translations.cartLabel}>
+            <Table size="small" aria-label={translations.header}>
               <TableHead>
                 <TableRow>
                   <TableCell>{translations.productNameHeader}</TableCell>

--- a/src/frontend/components/views/header.jsx
+++ b/src/frontend/components/views/header.jsx
@@ -13,6 +13,7 @@ import Nav from './nav';
 import Cart from './cart';
 import { SearchProductsByName } from '@frontend/components/views/search';
 import { useRWDLayout } from '@frontend/contexts/rwd-layout';
+import { getUrlToHome } from '@frontend/components/pages/home';
 
 const translations = Object.freeze({
   appMainHeader: 'PEV Shop',
@@ -42,7 +43,7 @@ export default observer(function Header() {
           level={1}
           className={classNames('header__main-heading', { 'header__main-heading--small': isHeadingSmall })}
         >
-          <PEVLink to={ROUTES.ROOT}>{translations.appMainHeader}</PEVLink>
+          <PEVLink to={getUrlToHome(routesGuards)}>{translations.appMainHeader}</PEVLink>
         </PEVHeading>
 
         <SearchProductsByName

--- a/src/frontend/components/views/header.jsx
+++ b/src/frontend/components/views/header.jsx
@@ -13,7 +13,6 @@ import Nav from './nav';
 import Cart from './cart';
 import { SearchProductsByName } from '@frontend/components/views/search';
 import { useRWDLayout } from '@frontend/contexts/rwd-layout';
-import { getUrlToHome } from '@frontend/components/pages/home';
 
 const translations = Object.freeze({
   appMainHeader: 'PEV Shop',
@@ -33,7 +32,7 @@ export default observer(function Header() {
       TODO: [UX] if current subpage is not a product list, then show some information 
       that subpage redirection will be made to avoid surprising user
     */
-    history.push(ROUTES.SHOP, { searchedProducts });
+    history.push(ROUTES.PRODUCTS, { searchedProducts });
   };
 
   return (
@@ -43,7 +42,7 @@ export default observer(function Header() {
           level={1}
           className={classNames('header__main-heading', { 'header__main-heading--small': isHeadingSmall })}
         >
-          <PEVLink to={getUrlToHome(routesGuards)}>{translations.appMainHeader}</PEVLink>
+          <PEVLink to={ROUTES.ROOT}>{translations.appMainHeader}</PEVLink>
         </PEVHeading>
 
         <SearchProductsByName

--- a/src/frontend/components/views/main.jsx
+++ b/src/frontend/components/views/main.jsx
@@ -1,8 +1,7 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Route, Switch, Redirect } from 'react-router-dom';
 import { observer } from 'mobx-react-lite';
 
-import userSessionService from '@frontend/features/userSessionService';
 import { ROUTES, useRoutesGuards } from '@frontend/components/pages/_routes';
 import storeService from '@frontend/features/storeService';
 import Home from '@frontend/components/pages/home';
@@ -20,13 +19,6 @@ import { ScrollToTop } from '@frontend/components/utils/scrollToTop';
 
 export default observer(function Main() {
   const routesGuards = useRoutesGuards(storeService);
-
-  /*
-    TODO: [UX] save user session to storage when page is unloaded (like by reloading or closing it).
-    It may be done via window's 'beforeunload' event, but it's better to use Page Lifecycle (API)
-    https://developers.google.com/web/updates/2018/07/page-lifecycle-api#observing-page-lifecycle-states-in-code
-  */
-  useEffect(userSessionService.restoreSession, []);
 
   return (
     <main className="main">

--- a/src/frontend/components/views/main.jsx
+++ b/src/frontend/components/views/main.jsx
@@ -5,7 +5,7 @@ import { observer } from 'mobx-react-lite';
 import { ROUTES, useRoutesGuards } from '@frontend/components/pages/_routes';
 import storeService from '@frontend/features/storeService';
 import Home from '@frontend/components/pages/home';
-import Shop from '@frontend/components/pages/shop';
+import Products from '@frontend/components/pages/products';
 import Register from '@frontend/components/pages/register';
 import NotLoggedIn from '@frontend/components/pages/notLoggedIn';
 import NotAuthorized from '@frontend/components/pages/notAuthorized';
@@ -28,8 +28,8 @@ export default observer(function Main() {
         </Route>
 
         <Route path={ROUTES.PAGES}>
-          <Route path={ROUTES.SHOP}>
-            <Shop />
+          <Route path={ROUTES.PRODUCTS}>
+            <Products />
           </Route>
           <Route path={ROUTES.REGISTER}>
             <Register />
@@ -59,8 +59,14 @@ export default observer(function Main() {
               routesGuards.isUser() ? <Account /> : <Redirect to={ROUTES.NOT_LOGGED_IN} />
             }
           </Route>
+
+          {/* for explicit redirection to 404 */}
+          <Route path={ROUTES.NOT_FOUND}>
+            <NotFound />
+          </Route>
         </Route>
 
+        {/* for unexpected 404 */}
         <Route>
           <NotFound />
         </Route>

--- a/src/frontend/components/views/nav.jsx
+++ b/src/frontend/components/views/nav.jsx
@@ -4,9 +4,16 @@ import { observer } from 'mobx-react-lite';
 
 import Menu from '@material-ui/icons/Menu';
 import Drawer from '@material-ui/core/Drawer';
+import Divider from '@material-ui/core/Divider';
 import CloseIcon from '@material-ui/icons/Close';
 import MenuList from '@material-ui/core/MenuList';
 import MenuItem from '@material-ui/core/MenuItem';
+import ListIcon from '@material-ui/icons/List';
+import AddToListIcon from '@material-ui/icons/PlaylistAdd';
+import AccountCircleIcon from '@material-ui/icons/AccountCircle';
+import ExitToAppIcon from '@material-ui/icons/ExitToApp';
+import PersonAddIcon from '@material-ui/icons/PersonAdd';
+import VpnKeyIcon from '@material-ui/icons/VpnKey';
 
 import { PEVIconButton, PEVLink } from '@frontend/components/utils/pevElements';
 import storeService from '@frontend/features/storeService';
@@ -16,13 +23,13 @@ import { useRWDLayout } from '@frontend/contexts/rwd-layout';
 
 const translations = Object.freeze({
   toggleNavMenu: 'Menu',
-  shop: 'Shop',
+  products: 'Products',
   addNewProduct: 'Add new product',
   modifyProduct: 'Modify product',
   register: 'Register',
   logIn: 'Log in',
   logOut: 'Log out',
-  account: 'Account',
+  getAccountLinkLabel: (login) => `go to "${login}" user account`,
 });
 
 /*
@@ -36,32 +43,44 @@ const NavMenu = observer(({ logOutUser }) => {
     <nav className="nav-menu">
       <MenuList className="nav-menu__links">
         <MenuItem>
-          <PEVLink to={ROUTES.SHOP}>{translations.shop}</PEVLink>
+          <PEVLink to={ROUTES.PRODUCTS}>
+            <ListIcon fontSize="inherit" />
+            {translations.products}
+          </PEVLink>
         </MenuItem>
         {routesGuards.isSeller() && [
-          <MenuItem key="ROUTES.ADD_NEW_PRODUCT">
-            <PEVLink to={ROUTES.ADD_NEW_PRODUCT}>{translations.addNewProduct}</PEVLink>
-          </MenuItem>,
-          <MenuItem key="ROUTES.MODIFY_PRODUCT">
-            <PEVLink to={ROUTES.MODIFY_PRODUCT}>{translations.modifyProduct}</PEVLink>
+          <MenuItem key="ROUTES.PRODUCTS__ADD_NEW_PRODUCT">
+            <PEVLink to={ROUTES.PRODUCTS__ADD_NEW_PRODUCT}>
+              <AddToListIcon fontSize="inherit" />
+              {translations.addNewProduct}
+            </PEVLink>
           </MenuItem>,
         ]}
         <MenuItem>
           {routesGuards.isUser() ? (
             <PEVLink to={ROUTES.ROOT} onClick={logOutUser}>
+              <ExitToAppIcon fontSize="inherit" />
               {translations.logOut}
             </PEVLink>
           ) : (
             <PEVLink to={ROUTES.LOG_IN} data-cy={`link:${ROUTES.LOG_IN}`}>
+              <VpnKeyIcon fontSize="inherit" />
               {translations.logIn}
             </PEVLink>
           )}
         </MenuItem>
         <MenuItem>
           {routesGuards.isUser() ? (
-            <PEVLink to={ROUTES.ACCOUNT}>{translations.account}</PEVLink>
+            <PEVLink
+              to={ROUTES.ACCOUNT}
+              aria-label={translations.getAccountLinkLabel(storeService.userAccountState.login)}
+            >
+              <AccountCircleIcon fontSize="inherit" />
+              {storeService.userAccountState.login}
+            </PEVLink>
           ) : (
             <PEVLink to={ROUTES.REGISTER} data-cy={`link:${ROUTES.REGISTER}`}>
+              <PersonAddIcon fontSize="inherit" />
               {translations.register}
             </PEVLink>
           )}
@@ -116,6 +135,8 @@ export default function Nav() {
         <PEVIconButton className="nav-close-btn" onClick={handleToggleNavMenu} a11y={translations.toggleNavMenu}>
           <CloseIcon />
         </PEVIconButton>
+
+        <Divider />
 
         <NavMenu logOutUser={logOutUser} />
       </Drawer>

--- a/src/frontend/components/views/productCard.jsx
+++ b/src/frontend/components/views/productCard.jsx
@@ -66,7 +66,7 @@ export function ProductCardLink({
     <Link
       {...restProps}
       to={{
-        pathname: `${ROUTES.PRODUCT}/${productData.url}`,
+        pathname: `${ROUTES.PRODUCTS}/${productData.url}`,
         state: productData,
       }}
       data-cy="link:product-card__link"
@@ -114,7 +114,7 @@ export default observer(function ProductCard({
   /* eslint-disable react/jsx-key */
   const menuItems = [
     routesGuards.isSeller()
-      ? [<NavigateToModifyProduct productName={name} />, <DeleteProductFeature productName={name} />]
+      ? [<NavigateToModifyProduct productData={product} />, <DeleteProductFeature productName={name} />]
       : [],
     routesGuards.isGuest() || routesGuards.isClient() ? (
       <AddToCartButton productInfoForCart={{ name, price, _id }} />

--- a/src/frontend/components/views/productComparisonCandidates.jsx
+++ b/src/frontend/components/views/productComparisonCandidates.jsx
@@ -248,7 +248,7 @@ export const ProductComparisonCandidatesList = observer(function CompareProducts
         <div className="product-comparison-candidates__actions">
           <PEVIconButton
             component={PEVLink}
-            to={{ pathname: ROUTES.COMPARE }}
+            to={{ pathname: ROUTES.PRODUCTS__COMPARE }}
             onClick={showOptionalWarning}
             a11y={translations.proceedComparison}
             data-cy="link:product-comparison-candidates__actions-proceed"

--- a/src/frontend/contexts/rwd-layout.tsx
+++ b/src/frontend/contexts/rwd-layout.tsx
@@ -53,6 +53,7 @@ const useRWDMediaQuery = () => {
     () =>
       mediaQueryList.reduce((output, { __deviceName: mqName }) => {
         const upperCasedMQName = `${mqName[0].toUpperCase()}${mqName.slice(1)}`;
+        // e.g.: isMobileLayout, isTabletLayout, isDesktopLayout
         const getterName = `is${upperCasedMQName}Layout`;
 
         return {

--- a/src/frontend/features/httpService.ts
+++ b/src/frontend/features/httpService.ts
@@ -7,6 +7,7 @@ import type {
 } from '@middleware/helpers/middleware-response-wrapper';
 import type { TProductTechnicalSpecs } from '@middleware/helpers/api-products-specs-mapper';
 import { HTTP_STATUS_CODE, IOrder, TPagination } from '@src/types';
+import storeService from '@frontend/features/storeService';
 
 type TResDataType<T> = T[keyof T];
 
@@ -235,11 +236,11 @@ const httpService = new (class HttpService extends Ajax {
     return this.getRequest({ url: this.URLS.PRODUCTS, searchParams });
   }
 
-  getProductsById(idList: string[]) {
+  getProductsById(idList: IProduct['_id'][]) {
     return this.getRequest(`${this.URLS.PRODUCTS}?idList=${idList}`);
   }
 
-  getProductsByNames(nameList: string[]) {
+  getProductsByNames(nameList: IProduct['name'][]) {
     const searchParams = new URLSearchParams({ nameList: JSON.stringify(nameList) });
 
     return this.getRequest({
@@ -248,12 +249,19 @@ const httpService = new (class HttpService extends Ajax {
     });
   }
 
-  getProductsByName(name: string, caseSensitive = 'false', pagination: TPagination) {
+  getProductsByName(name: IProduct['name'], caseSensitive = 'false', pagination: TPagination) {
     const searchParams = new URLSearchParams();
     searchParams.append('name', name);
     searchParams.append('caseSensitive', caseSensitive);
 
     this._preparePaginationParams(searchParams, pagination);
+
+    return this.getRequest({ url: this.URLS.PRODUCTS, searchParams });
+  }
+
+  getProductByUrl(url: IProduct['url']) {
+    const searchParams = new URLSearchParams();
+    searchParams.append('url', url);
 
     return this.getRequest({ url: this.URLS.PRODUCTS, searchParams });
   }
@@ -291,8 +299,13 @@ const httpService = new (class HttpService extends Ajax {
     return this.deleteRequest(`${this.URLS.PRODUCTS}/${productName}`, true);
   }
 
-  getUser() {
-    const userId = '5f5a8dce154f830fd840dc7b';
+  getCurrentUser() {
+    const userId = storeService.userAccountState?._id;
+
+    if (!userId) {
+      throw Error(`Current user's id is not available! User is probably not logged in.`);
+    }
+
     return this.getRequest(`${this.URLS.USERS}/${userId}`, true);
   }
 

--- a/src/middleware/routes/api-products.ts
+++ b/src/middleware/routes/api-products.ts
@@ -89,6 +89,7 @@ async function getProducts(req: Request, res: Response, next: NextFunction) {
     const nameListConfig = queryBuilder.getNameListConfig(req.query);
     const chosenCategories = queryBuilder.getProductsWithChosenCategories(req.query);
     const searchByName = queryBuilder.getSearchByNameConfig(req.query);
+    const searchByUrl = queryBuilder.getSearchByUrlConfig(req.query);
     const filters = queryBuilder.getFilters(req.query);
 
     let query = {};
@@ -101,6 +102,8 @@ async function getProducts(req: Request, res: Response, next: NextFunction) {
       query = chosenCategories;
     } else if (searchByName) {
       query = searchByName;
+    } else if (searchByUrl) {
+      query = searchByUrl;
     } else if (filters) {
       query = filters;
     }
@@ -114,13 +117,15 @@ async function getProducts(req: Request, res: Response, next: NextFunction) {
       options.pagination = paginationConfig;
     }
 
-    const paginatedProducts = await getFromDB({ modelName: COLLECTION_NAMES.Product, ...options }, query);
+    const paginatedProducts = (await getFromDB({ modelName: COLLECTION_NAMES.Product, ...options }, query)) as
+      | IProduct[]
+      | null;
 
-    if (!paginatedProducts) {
+    if (!paginatedProducts || paginatedProducts.length === 0) {
       return wrapRes(res, HTTP_STATUS_CODE.NOT_FOUND, { error: 'Products not found!' });
     }
 
-    return wrapRes(res, HTTP_STATUS_CODE.OK, { payload: paginatedProducts as IProduct[] });
+    return wrapRes(res, HTTP_STATUS_CODE.OK, { payload: paginatedProducts });
   } catch (exception) {
     return next(exception);
   }

--- a/test/e2e/cypress/integration/account.spec.ts
+++ b/test/e2e/cypress/integration/account.spec.ts
@@ -12,12 +12,6 @@ const ACCOUNT_TEST_USER: TE2EUser = Object.freeze({
 });
 
 describe('#account', () => {
-  const ACCOUNT_URLS = Object.freeze({
-    USER_PROFILE: `${ROUTES.ACCOUNT}/user-profile`,
-    SECURITY: `${ROUTES.ACCOUNT}/security`,
-    OBSERVED_PRODUCTS: `${ROUTES.ACCOUNT}/observed-products`,
-    ORDERS: `${ROUTES.ACCOUNT}/orders`,
-  });
   const goToNewUserAccount = () => {
     cy.registerAndLoginTestUser(ACCOUNT_TEST_USER);
 
@@ -33,14 +27,14 @@ describe('#account', () => {
     goToNewUserAccount();
 
     [
-      { name: 'Profile', url: ACCOUNT_URLS.USER_PROFILE, dataCySection: 'section:user-profile' },
-      { name: 'Security', url: ACCOUNT_URLS.SECURITY, dataCySection: 'section:security' },
+      { name: 'Profile', url: ROUTES.ACCOUNT__USER_PROFILE, dataCySection: 'section:user-profile' },
+      { name: 'Security', url: ROUTES.ACCOUNT__SECURITY, dataCySection: 'section:security' },
       {
         name: 'Observed products',
-        url: ACCOUNT_URLS.OBSERVED_PRODUCTS,
+        url: ROUTES.ACCOUNT__OBSERVED_PRODUCTS,
         dataCySection: 'section:observed-products',
       },
-      { name: 'Orders', url: ACCOUNT_URLS.ORDERS, dataCySection: 'section:orders' },
+      { name: 'Orders', url: ROUTES.ACCOUNT__ORDERS, dataCySection: 'section:orders' },
     ].forEach(({ name, url, dataCySection }) => {
       cy.get(makeCyDataSelector('link:account-feature')).contains(name).and('have.attr', 'href', url).click();
       cy.location('pathname').should('eq', url);
@@ -51,7 +45,7 @@ describe('#account', () => {
   it('should show profile details', () => {
     goToNewUserAccount();
 
-    cy.get(`${makeCyDataSelector('link:account-feature')}[href="${ACCOUNT_URLS.USER_PROFILE}"]`).click();
+    cy.get(`${makeCyDataSelector('link:account-feature')}[href="${ROUTES.ACCOUNT__USER_PROFILE}"]`).click();
     cy.getFromStorage<TUserPublic>('userAccount').then((user) => {
       const profileDetails = [
         { header: 'login', data: user.login },
@@ -135,7 +129,7 @@ describe('#account', () => {
       cy.get(makeCyDataSelector('button:logout-from-other-sessions')).click();
       cy.get(makeCyDataSelector('button:confirm-logging-out-from-multiple-sessions')).click();
 
-      cy.location('pathname').should('eq', `${ROUTES.ACCOUNT}/security`);
+      cy.location('pathname').should('eq', ROUTES.ACCOUNT__SECURITY);
       cy.getFromStorage('userAuthToken').should('have.length.gte', 0);
       confirmEndedAlternativeSession();
 

--- a/test/e2e/cypress/integration/login.spec.ts
+++ b/test/e2e/cypress/integration/login.spec.ts
@@ -28,7 +28,7 @@ describe('#login', () => {
     });
     cy.get(makeCyDataSelector('button:submit-login')).click();
 
-    cy.location('pathname').should('eq', ROUTES.ROOT);
+    cy.location('pathname').should('eq', ROUTES.ACCOUNT__ORDERS);
     cy.get(makeCyDataSelector(`link:${ROUTES.LOG_IN}`)).should('not.exist');
   });
 

--- a/test/e2e/cypress/integration/order.spec.ts
+++ b/test/e2e/cypress/integration/order.spec.ts
@@ -122,7 +122,7 @@ describe('order', () => {
     // add product to cart
     cy.visit(ROUTES.LOG_IN);
     cy.loginTestUserByUI(exampleUser);
-    cy.visit(ROUTES.SHOP);
+    cy.visit(ROUTES.PRODUCTS);
 
     cy.get(makeCyDataSelector('container:product-card_0'))
       .first()
@@ -166,7 +166,7 @@ describe('order', () => {
 
     // go to order page
     cy.get(makeCyDataSelector('button:submit-cart')).click();
-    cy.location('pathname').should('eq', ROUTES.ORDER);
+    cy.location('pathname').should('eq', ROUTES.PRODUCTS__ORDER);
 
     // assert form is empty
     cy.get(makeCyDataSelector('input:receiver-name')).as('nameInput').should('have.value', '');
@@ -249,7 +249,7 @@ describe('order', () => {
 
     // go to order page
     cy.get(makeCyDataSelector('button:submit-cart')).click();
-    cy.location('pathname').should('eq', ROUTES.ORDER);
+    cy.location('pathname').should('eq', ROUTES.PRODUCTS__ORDER);
 
     // fill basic form data
     cy.get(makeCyDataSelector('input:receiver-name')).type(testReceiver.name);

--- a/test/e2e/cypress/integration/product-comparing.spec.ts
+++ b/test/e2e/cypress/integration/product-comparing.spec.ts
@@ -59,7 +59,7 @@ describe('product-comparing', () => {
   };
 
   beforeEach(() => {
-    cy.visit(ROUTES.SHOP);
+    cy.visit(ROUTES.PRODUCTS);
     cy.get(makeCyDataSelector('button:product-comparison-candidates__actions-clear')).click({ force: true });
     cy.get(makeCyDataSelector('container:product-comparison-candidates__list')).children().should('have.length', 0);
   });
@@ -168,7 +168,7 @@ describe('product-comparing', () => {
       cy.get(makeCyDataSelector('counter:product-comparison-candidates__list-counter')).contains(productIndex + 1);
 
       // go back to products list
-      cy.get(`a[href="${ROUTES.SHOP}"]`).click();
+      cy.get(`a[href="${ROUTES.PRODUCTS}"]`).click();
 
       // let caller to chain the result
       return cy.wrap(null);
@@ -238,7 +238,7 @@ describe('product-comparing', () => {
       }
 
       // go back to products list
-      cy.get(`a[href="${ROUTES.SHOP}"]`).click();
+      cy.get(`a[href="${ROUTES.PRODUCTS}"]`).click();
     }
   });
 
@@ -264,10 +264,10 @@ describe('product-comparing', () => {
     // assert warning popup doesn't show up
     cy.get(makeCyDataSelector('link:product-comparison-candidates__actions-proceed')).click();
     cy.get(makeCyDataSelector('popup:message')).should('not.exist');
-    cy.location('pathname').should('eq', ROUTES.COMPARE);
+    cy.location('pathname').should('eq', ROUTES.PRODUCTS__COMPARE);
 
     // go to third product's page
-    cy.get(`a[href="${ROUTES.SHOP}"]`).click();
+    cy.get(`a[href="${ROUTES.PRODUCTS}"]`).click();
     cy.get(makeCyDataSelector('label:product-card__name'))
       .eq(3)
       .closest(makeCyDataSelector('link:product-card__link'))
@@ -298,7 +298,7 @@ describe('product-comparing', () => {
     cy.get(makeCyDataSelector('link:product-comparison-candidates__actions-proceed')).click();
 
     // assertions
-    cy.location('pathname').should('eq', ROUTES.COMPARE);
+    cy.location('pathname').should('eq', ROUTES.PRODUCTS__COMPARE);
     cy.contains(makeCyDataSelector('label:product-comparison__header-counter'), '4');
     cy.get(makeCyDataSelector('label:product-detail__name')).then(($comparedProductsNameElements) => {
       const $comparedProductNames = $comparedProductsNameElements.map((_, { textContent }) => textContent);

--- a/test/e2e/cypress/integration/product-filters.spec.ts
+++ b/test/e2e/cypress/integration/product-filters.spec.ts
@@ -17,7 +17,7 @@ function assertProductsFilterQueryParam(url: string, objectToAssertInclusion: { 
 describe('product-filters', () => {
   it('should find products regarding applied filters', () => {
     // prepare
-    cy.visit(ROUTES.SHOP);
+    cy.visit(ROUTES.PRODUCTS);
     cy.get(makeCyDataSelector('container:products-filter'))
       .children()
       .as('productsFiltersContainer')

--- a/test/e2e/cypress/integration/product-form.spec.ts
+++ b/test/e2e/cypress/integration/product-form.spec.ts
@@ -11,7 +11,7 @@ describe('product-form', () => {
   let authToken: string;
 
   const goToProductModificationPage = (productName: string) => {
-    cy.visit(ROUTES.SHOP);
+    cy.visit(ROUTES.PRODUCTS);
     cy.get(makeCyDataSelector('input:the-search')).type(productName);
     cy.contains(makeCyDataSelector('label:product-card__name'), productName)
       .closest(makeCyDataSelector('link:product-card__link'))
@@ -147,7 +147,7 @@ describe('product-form', () => {
   context('add new product', () => {
     it('should add new product', () => {
       // assert that to-be-added product doesn't exist yet
-      cy.visit(ROUTES.SHOP);
+      cy.visit(ROUTES.PRODUCTS);
       cy.get(makeCyDataSelector('input:the-search')).type(testProductDataForForm.name);
       cy.get(makeCyDataSelector('list:product-list')).should(($list) => {
         expect($list.text()).to.equal('Lack of products...');
@@ -155,7 +155,7 @@ describe('product-form', () => {
       });
 
       // go to adding new product page
-      cy.get(`a[href="${ROUTES.ADD_NEW_PRODUCT}"]`).click();
+      cy.get(`a[href="${ROUTES.PRODUCTS__ADD_NEW_PRODUCT}"]`).click();
 
       // assert form is empty
       cy.get(makeCyDataSelector('input:base__name')).should('have.value', '');

--- a/test/unit/middleware/routes/api-products.spec.ts
+++ b/test/unit/middleware/routes/api-products.spec.ts
@@ -102,6 +102,9 @@ describe('#api-products', () => {
         queryBuilderMock.getSearchByNameConfig.mockImplementationOnce(
           queryBuilderMock.getSearchByNameConfig._succeededCall
         );
+        queryBuilderMock.getSearchByUrlConfig.mockImplementationOnce(
+          queryBuilderMock.getSearchByUrlConfig._succeededCall
+        );
         queryBuilderMock.getFilters.mockImplementationOnce(queryBuilderMock.getFilters._succeededCall);
         getFromDBMock.mockImplementationOnce(getFromDBMock._succeededCall);
       });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -95,6 +95,7 @@ module.exports = (env) => {
           'src/database',
           'test/middleware',
           'test/database',
+          '__mocks__'
         ].map((path) => resolve(__dirname, path)),
       },
     },


### PR DESCRIPTION
- prepare home page boilerplate to show products regarding a few categories (fetching initial data *has to be implemented*):
  - best sellers,
  - top rated,
  - recently added,
  - recently viewed,

  with links to redirect user to related search with already applied filters (*to be implemented*)
- refactor routes by dividing them into groups: "PRODUCTS" and "ACCOUNT" (so far), so routing can be structured in BEM-like form
- normalize product URL while adding it to database, by transforming with [percentage encoding](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding) (so far only slash characters), which mitigates issue with not recognizing route for specified product when it has unexpected characters
- add searching product by URL, so user can directly navigate to it's view
- improve navigating to `/modify-product` page, so user can directly go there via product's URL
- show logged user name instead of "Account" label under regarding navigation element
- add icons for nav elements
- make `NotFound` component a bit customizable (when user is directly navigated to it), so it can tell user more about not found resource
- move restoring user session to the app's root, so it will act quicker than when being triggered from `Main` component's `useEffect`
- fix fetching current user data
- simplify handling paths from CLI params inside `populate.ts` module and make it exit the process after population is finished