### PR TITLE
Extend products dashboard sorting, add product form successful popup and complete home page

### DIFF
--- a/api-docs/commons.md
+++ b/api-docs/commons.md
@@ -55,7 +55,7 @@ fake-pev-shopping
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:18](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L18)
+[src/frontend/features/storageService.ts:18](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L18)
 
 ## Properties
 
@@ -65,7 +65,7 @@ fake-pev-shopping
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:16](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L16)
+[src/frontend/features/storageService.ts:16](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L16)
 
 ## Methods
 
@@ -81,7 +81,7 @@ Already parsed (from JSON) stored value.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:42](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L42)
+[src/frontend/features/storageService.ts:42](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L42)
 
 ___
 
@@ -97,7 +97,7 @@ Removes a values.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:54](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L54)
+[src/frontend/features/storageService.ts:54](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L54)
 
 ___
 
@@ -121,7 +121,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:26](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L26)
+[src/frontend/features/storageService.ts:26](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L26)
 
 [fake-pev-shopping](#readmemd) / [types](#modulestypesmd) / [<internal\>](#modulestypes_internal_md) / StoreService
 
@@ -165,7 +165,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:27](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L27)
+[src/frontend/features/storeService.ts:27](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L27)
 
 ## Accessors
 
@@ -179,7 +179,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:151](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L151)
+[src/frontend/features/storeService.ts:151](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L151)
 
 ___
 
@@ -193,7 +193,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:147](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L147)
+[src/frontend/features/storeService.ts:147](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L147)
 
 ___
 
@@ -207,7 +207,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:135](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L135)
+[src/frontend/features/storeService.ts:135](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L135)
 
 ___
 
@@ -221,7 +221,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:143](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L143)
+[src/frontend/features/storeService.ts:143](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L143)
 
 ___
 
@@ -235,7 +235,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:131](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L131)
+[src/frontend/features/storeService.ts:131](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L131)
 
 ___
 
@@ -249,7 +249,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:139](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L139)
+[src/frontend/features/storeService.ts:139](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L139)
 
 ## Methods
 
@@ -274,7 +274,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:48](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L48)
+[src/frontend/features/storeService.ts:48](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L48)
 
 ___
 
@@ -288,7 +288,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:119](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L119)
+[src/frontend/features/storeService.ts:119](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L119)
 
 ___
 
@@ -302,7 +302,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:127](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L127)
+[src/frontend/features/storeService.ts:127](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L127)
 
 ___
 
@@ -316,7 +316,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:43](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L43)
+[src/frontend/features/storeService.ts:43](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L43)
 
 ___
 
@@ -330,7 +330,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:89](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L89)
+[src/frontend/features/storeService.ts:89](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L89)
 
 ___
 
@@ -355,7 +355,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:69](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L69)
+[src/frontend/features/storeService.ts:69](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L69)
 
 ___
 
@@ -375,7 +375,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:96](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L96)
+[src/frontend/features/storeService.ts:96](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L96)
 
 ___
 
@@ -402,7 +402,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:102](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L102)
+[src/frontend/features/storeService.ts:102](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L102)
 
 ___
 
@@ -422,7 +422,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:123](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L123)
+[src/frontend/features/storeService.ts:123](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L123)
 
 ___
 
@@ -442,7 +442,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:39](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L39)
+[src/frontend/features/storeService.ts:39](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L39)
 
 [fake-pev-shopping](#readmemd) / [types](#modulestypesmd) / [<internal\>](#modulestypes_internal_md) / UserAccount
 
@@ -490,7 +490,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:70](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L70)
+[src/frontend/features/storageService.ts:70](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L70)
 
 ## Properties
 
@@ -504,7 +504,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:16](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L16)
+[src/frontend/features/storageService.ts:16](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L16)
 
 ## Methods
 
@@ -524,7 +524,7 @@ Already parsed (from JSON) stored value.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:42](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L42)
+[src/frontend/features/storageService.ts:42](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L42)
 
 ___
 
@@ -544,7 +544,7 @@ Removes a values.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:54](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L54)
+[src/frontend/features/storageService.ts:54](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L54)
 
 ___
 
@@ -571,7 +571,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:74](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L74)
+[src/frontend/features/storageService.ts:74](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L74)
 
 [fake-pev-shopping](#readmemd) / [types](#modulestypesmd) / [<internal\>](#modulestypes_internal_md) / UserAuthToken
 
@@ -619,7 +619,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:80](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L80)
+[src/frontend/features/storageService.ts:80](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L80)
 
 ## Properties
 
@@ -633,7 +633,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:16](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L16)
+[src/frontend/features/storageService.ts:16](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L16)
 
 ## Methods
 
@@ -653,7 +653,7 @@ Already parsed (from JSON) stored value.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:42](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L42)
+[src/frontend/features/storageService.ts:42](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L42)
 
 ___
 
@@ -673,7 +673,7 @@ Removes a values.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:54](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L54)
+[src/frontend/features/storageService.ts:54](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L54)
 
 ___
 
@@ -700,7 +700,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:84](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L84)
+[src/frontend/features/storageService.ts:84](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L84)
 
 [fake-pev-shopping](#readmemd) / [types](#modulestypesmd) / [<internal\>](#modulestypes_internal_md) / UserCart
 
@@ -748,7 +748,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:60](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L60)
+[src/frontend/features/storageService.ts:60](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L60)
 
 ## Properties
 
@@ -762,7 +762,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:16](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L16)
+[src/frontend/features/storageService.ts:16](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L16)
 
 ## Methods
 
@@ -782,7 +782,7 @@ Already parsed (from JSON) stored value.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:42](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L42)
+[src/frontend/features/storageService.ts:42](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L42)
 
 ___
 
@@ -802,7 +802,7 @@ Removes a values.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:54](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L54)
+[src/frontend/features/storageService.ts:54](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L54)
 
 ___
 
@@ -829,7 +829,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:64](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L64)
+[src/frontend/features/storageService.ts:64](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L64)
 
 [fake-pev-shopping](#readmemd) / [types](#modulestypesmd) / HTTP\_STATUS\_CODE
 
@@ -862,7 +862,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[commons/types.ts:50](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L50)
+[commons/types.ts:50](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L50)
 
 ___
 
@@ -872,7 +872,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:54](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L54)
+[commons/types.ts:54](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L54)
 
 ___
 
@@ -882,7 +882,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:46](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L46)
+[commons/types.ts:46](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L46)
 
 ___
 
@@ -892,7 +892,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:52](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L52)
+[commons/types.ts:52](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L52)
 
 ___
 
@@ -902,7 +902,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:55](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L55)
+[commons/types.ts:55](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L55)
 
 ___
 
@@ -912,7 +912,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:57](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L57)
+[commons/types.ts:57](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L57)
 
 ___
 
@@ -922,7 +922,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:53](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L53)
+[commons/types.ts:53](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L53)
 
 ___
 
@@ -932,7 +932,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:49](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L49)
+[commons/types.ts:49](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L49)
 
 ___
 
@@ -942,7 +942,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:47](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L47)
+[commons/types.ts:47](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L47)
 
 ___
 
@@ -952,7 +952,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:45](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L45)
+[commons/types.ts:45](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L45)
 
 ___
 
@@ -962,7 +962,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:56](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L56)
+[commons/types.ts:56](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L56)
 
 ___
 
@@ -972,7 +972,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:51](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L51)
+[commons/types.ts:51](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L51)
 
 [fake-pev-shopping](#readmemd) / [types](#modulestypesmd) / IOrderPayload
 
@@ -1003,7 +1003,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:78](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L78)
+[commons/types.ts:78](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L78)
 
 ___
 
@@ -1013,7 +1013,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:85](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L85)
+[commons/types.ts:85](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L85)
 
 ___
 
@@ -1031,7 +1031,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:73](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L73)
+[commons/types.ts:73](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L73)
 
 ___
 
@@ -1048,7 +1048,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:81](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L81)
+[commons/types.ts:81](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L81)
 
 [fake-pev-shopping](#readmemd) / [types](#modulestypesmd) / IPayByLinkMethod
 
@@ -1075,7 +1075,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:39](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L39)
+[commons/types.ts:39](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L39)
 
 ___
 
@@ -1085,7 +1085,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:38](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L38)
+[commons/types.ts:38](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L38)
 
 ___
 
@@ -1095,7 +1095,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:36](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L36)
+[commons/types.ts:36](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L36)
 
 ___
 
@@ -1105,7 +1105,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:37](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L37)
+[commons/types.ts:37](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L37)
 
 ___
 
@@ -1115,7 +1115,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:34](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L34)
+[commons/types.ts:34](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L34)
 
 ___
 
@@ -1125,7 +1125,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:35](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L35)
+[commons/types.ts:35](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L35)
 
 [fake-pev-shopping](#readmemd) / [types](#modulestypesmd) / IProductInOrder
 
@@ -1149,7 +1149,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:28](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L28)
+[commons/types.ts:28](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L28)
 
 ___
 
@@ -1159,7 +1159,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:30](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L30)
+[commons/types.ts:30](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L30)
 
 ___
 
@@ -1169,7 +1169,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:29](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L29)
+[commons/types.ts:29](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L29)
 
 [fake-pev-shopping](#readmemd) / [types](#modulestypesmd) / IUserCart
 
@@ -1193,7 +1193,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:61](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L61)
+[commons/types.ts:61](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L61)
 
 ___
 
@@ -1203,7 +1203,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:68](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L68)
+[commons/types.ts:68](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L68)
 
 ___
 
@@ -1213,7 +1213,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:69](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L69)
+[commons/types.ts:69](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L69)
 
 [fake-pev-shopping](#readmemd) / [types](#modulestypesmd) / [<internal\>](#modulestypes_internal_md) / ICustomResExt
 
@@ -1237,7 +1237,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:604](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L604)
+[src/frontend/features/httpService.ts:604](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L604)
 
 ___
 
@@ -1247,7 +1247,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:605](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L605)
+[src/frontend/features/httpService.ts:605](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L605)
 
 ___
 
@@ -1257,7 +1257,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:603](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L603)
+[src/frontend/features/httpService.ts:603](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L603)
 
 [fake-pev-shopping](#readmemd) / [types](#modulestypesmd) / [<internal\>](#modulestypes_internal_md) / IEmbracedResponse
 
@@ -1289,7 +1289,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:11](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L11)
+[src/middleware/helpers/middleware-response-wrapper.ts:11](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L11)
 
 ___
 
@@ -1299,7 +1299,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:14](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L14)
+[src/middleware/helpers/middleware-response-wrapper.ts:14](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L14)
 
 ___
 
@@ -1309,7 +1309,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:15](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L15)
+[src/middleware/helpers/middleware-response-wrapper.ts:15](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L15)
 
 ___
 
@@ -1319,7 +1319,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:13](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L13)
+[src/middleware/helpers/middleware-response-wrapper.ts:13](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L13)
 
 ___
 
@@ -1329,7 +1329,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:12](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L12)
+[src/middleware/helpers/middleware-response-wrapper.ts:12](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L12)
 
 [fake-pev-shopping](#readmemd) / [logger](#modulesloggermd) / <internal\>
 
@@ -1365,7 +1365,7 @@ Custom wrapper for a commonly used global `console` methods.
 
 #### Defined in
 
-[commons/logger.ts:72](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/logger.ts#L72)
+[commons/logger.ts:72](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/logger.ts#L72)
 
 ## Functions
 
@@ -1390,7 +1390,7 @@ Creates a module bound logger, which name will be visually emphased in output lo
 
 #### Defined in
 
-[commons/logger.ts:62](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/logger.ts#L62)
+[commons/logger.ts:62](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/logger.ts#L62)
 
 [fake-pev-shopping](#readmemd) / [types](#modulestypesmd) / <internal\>
 
@@ -1432,7 +1432,7 @@ Creates a module bound logger, which name will be visually emphased in output lo
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:9](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L9)
+[src/frontend/features/storageService.ts:9](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L9)
 
 ___
 
@@ -1442,7 +1442,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_user.ts:306](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_user.ts#L306)
+[src/database/models/_user.ts:306](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_user.ts#L306)
 
 ## Variables
 
@@ -1462,7 +1462,7 @@ Manipulating storage data API for various contexts, such as `UserCart` or `UserA
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:14](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L14)
+[src/frontend/features/storageService.ts:14](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L14)
 
 ___
 
@@ -1472,7 +1472,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:177](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L177)
+[src/frontend/features/storeService.ts:177](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L177)
 
 ___
 
@@ -1491,7 +1491,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/userSessionService.ts:12](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/userSessionService.ts#L12)
+[src/frontend/features/userSessionService.ts:12](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/userSessionService.ts#L12)
 
 [fake-pev-shopping](#readmemd) / types
 
@@ -1535,4 +1535,4 @@ Common types for whole app.
 
 #### Defined in
 
-[commons/types.ts:88](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L88)
+[commons/types.ts:88](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L88)

--- a/api-docs/database.md
+++ b/api-docs/database.md
@@ -52,7 +52,7 @@ fake-pev-shopping
 
 #### Defined in
 
-[src/database/models/_order.ts:180](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_order.ts#L180)
+[src/database/models/_order.ts:185](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_order.ts#L185)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_order.ts:185](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_order.ts#L185)
+[src/database/models/_order.ts:190](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_order.ts#L190)
 
 ___
 
@@ -90,7 +90,7 @@ Pick.receiver
 
 #### Defined in
 
-[src/database/models/_order.ts:179](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_order.ts#L179)
+[src/database/models/_order.ts:184](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_order.ts#L184)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_order.ts:193](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_order.ts#L193)
+[src/database/models/_order.ts:198](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_order.ts#L198)
 
 ___
 
@@ -110,7 +110,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_order.ts:192](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_order.ts#L192)
+[src/database/models/_order.ts:197](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_order.ts#L197)
 
 ___
 
@@ -127,7 +127,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_order.ts:188](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_order.ts#L188)
+[src/database/models/_order.ts:193](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_order.ts#L193)
 
 ___
 
@@ -137,7 +137,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_order.ts:178](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_order.ts#L178)
+[src/database/models/_order.ts:183](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_order.ts#L183)
 
 [fake-pev-shopping](#readmemd) / [models](#modulesmodelsmd) / IProduct
 
@@ -157,8 +157,10 @@ ___
 
 - [availability](#availability)
 - [category](#category)
+- [createdAt](#createdat)
 - [images](#images)
 - [name](#name)
+- [orderedUnits](#orderedunits)
 - [price](#price)
 - [relatedProductsNames](#relatedproductsnames)
 - [reviews](#reviews)
@@ -181,7 +183,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:458](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L458)
+[src/database/models/_product.ts:500](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L500)
 
 ___
 
@@ -191,7 +193,17 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:447](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L447)
+[src/database/models/_product.ts:489](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L489)
+
+___
+
+### createdAt
+
+• **createdAt**: `number`
+
+#### Defined in
+
+[src/database/models/_product.ts:502](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L502)
 
 ___
 
@@ -201,7 +213,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:455](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L455)
+[src/database/models/_product.ts:497](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L497)
 
 ___
 
@@ -211,7 +223,17 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:445](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L445)
+[src/database/models/_product.ts:487](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L487)
+
+___
+
+### orderedUnits
+
+• **orderedUnits**: `number`
+
+#### Defined in
+
+[src/database/models/_product.ts:501](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L501)
 
 ___
 
@@ -221,7 +243,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:448](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L448)
+[src/database/models/_product.ts:490](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L490)
 
 ___
 
@@ -231,7 +253,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:456](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L456)
+[src/database/models/_product.ts:498](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L498)
 
 ___
 
@@ -241,7 +263,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:457](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L457)
+[src/database/models/_product.ts:499](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L499)
 
 ___
 
@@ -251,7 +273,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:449](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L449)
+[src/database/models/_product.ts:491](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L491)
 
 ___
 
@@ -261,7 +283,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:450](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L450)
+[src/database/models/_product.ts:492](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L492)
 
 ___
 
@@ -271,7 +293,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:446](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L446)
+[src/database/models/_product.ts:488](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L488)
 
 ## Methods
 
@@ -292,7 +314,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:465](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L465)
+[src/database/models/_product.ts:509](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L509)
 
 ___
 
@@ -306,7 +328,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:460](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L460)
+[src/database/models/_product.ts:504](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L504)
 
 ___
 
@@ -320,7 +342,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:461](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L461)
+[src/database/models/_product.ts:505](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L505)
 
 ___
 
@@ -340,7 +362,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:462](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L462)
+[src/database/models/_product.ts:506](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L506)
 
 [fake-pev-shopping](#readmemd) / [models](#modulesmodelsmd) / [<internal\>](#modulesmodels_internal_md) / IOrderModel
 
@@ -409,7 +431,7 @@ node_modules/@types/mongoose/index.d.ts:3225
 
 #### Defined in
 
-[src/database/models/_order.ts:170](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_order.ts#L170)
+[src/database/models/_order.ts:175](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_order.ts#L175)
 
 ___
 
@@ -433,7 +455,7 @@ Model.execPopulate
 
 #### Defined in
 
-[src/augmentations.d.ts:27](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/augmentations.d.ts#L27)
+[src/augmentations.d.ts:27](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/augmentations.d.ts#L27)
 
 ▸ **execPopulate**(`options`): [`IOrderModel`](#interfacesmodels_internal_iordermodelmd)
 
@@ -453,7 +475,7 @@ Model.execPopulate
 
 #### Defined in
 
-[src/augmentations.d.ts:28](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/augmentations.d.ts#L28)
+[src/augmentations.d.ts:28](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/augmentations.d.ts#L28)
 
 ___
 
@@ -477,7 +499,7 @@ Model.populated
 
 #### Defined in
 
-[src/augmentations.d.ts:29](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/augmentations.d.ts#L29)
+[src/augmentations.d.ts:29](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/augmentations.d.ts#L29)
 
 [fake-pev-shopping](#readmemd) / [models](#modulesmodelsmd) / [<internal\>](#modulesmodels_internal_md) / IOrderPayload
 
@@ -508,7 +530,7 @@ Model.populated
 
 #### Defined in
 
-[commons/types.ts:78](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L78)
+[commons/types.ts:78](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L78)
 
 ___
 
@@ -518,7 +540,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:85](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L85)
+[commons/types.ts:85](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L85)
 
 ___
 
@@ -536,7 +558,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:73](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L73)
+[commons/types.ts:73](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L73)
 
 ___
 
@@ -553,7 +575,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:81](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L81)
+[commons/types.ts:81](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L81)
 
 [fake-pev-shopping](#readmemd) / [models](#modulesmodelsmd) / [<internal\>](#modulesmodels_internal_md) / IProductInOrder
 
@@ -577,7 +599,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:28](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L28)
+[commons/types.ts:28](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L28)
 
 ___
 
@@ -587,7 +609,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:30](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L30)
+[commons/types.ts:30](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L30)
 
 ___
 
@@ -597,7 +619,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:29](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L29)
+[commons/types.ts:29](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L29)
 
 [fake-pev-shopping](#readmemd) / [api](#modulesapimd) / <internal\>
 
@@ -624,7 +646,7 @@ ___
 
 #### Defined in
 
-[src/database/utils/paginateItemsFromDB.ts:26](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/utils/paginateItemsFromDB.ts#L26)
+[src/database/utils/paginateItemsFromDB.ts:26](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/utils/paginateItemsFromDB.ts#L26)
 
 ___
 
@@ -641,13 +663,13 @@ ___
 
 #### Defined in
 
-[src/database/utils/paginateItemsFromDB.ts:25](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/utils/paginateItemsFromDB.ts#L25)
+[src/database/utils/paginateItemsFromDB.ts:25](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/utils/paginateItemsFromDB.ts#L25)
 
 ## Functions
 
 ### getPaginatedItems
 
-▸ **getPaginatedItems**(`__namedParameters`, `itemQuery`, `projection`): `Promise`<`PaginateResult`<[`IProduct`](#interfacesmodelsiproductmd) \| `IUser` \| `IUserRole` \| [`IOrder`](#interfacesmodelsiordermd)\>\>
+▸ **getPaginatedItems**(`__namedParameters`, `itemQuery`, `projection`): `Promise`<`PaginateResult`<[`IProduct`](#interfacesmodelsiproductmd) \| [`IOrder`](#interfacesmodelsiordermd) \| `IUser` \| `IUserRole`\>\>
 
 #### Parameters
 
@@ -657,16 +679,16 @@ ___
 | `__namedParameters.Model` | [`TPaginateModel`](#tpaginatemodel) |
 | `__namedParameters.pagination` | [`TPaginationConfig`](#tpaginationconfig) |
 | `__namedParameters.sort?` | [`TSort`](#tsort) |
-| `itemQuery` | `undefined` \| `MongooseFilterQuery`<`Pick`<[`IProduct`](#interfacesmodelsiproductmd) \| `IUser` \| `IUserRole` \| [`IOrder`](#interfacesmodelsiordermd), ``"_id"``\>\> |
+| `itemQuery` | `undefined` \| `MongooseFilterQuery`<`Pick`<[`IProduct`](#interfacesmodelsiproductmd) \| [`IOrder`](#interfacesmodelsiordermd) \| `IUser` \| `IUserRole`, ``"_id"``\>\> |
 | `projection` | `any` |
 
 #### Returns
 
-`Promise`<`PaginateResult`<[`IProduct`](#interfacesmodelsiproductmd) \| `IUser` \| `IUserRole` \| [`IOrder`](#interfacesmodelsiordermd)\>\>
+`Promise`<`PaginateResult`<[`IProduct`](#interfacesmodelsiproductmd) \| [`IOrder`](#interfacesmodelsiordermd) \| `IUser` \| `IUserRole`\>\>
 
 #### Defined in
 
-[src/database/utils/paginateItemsFromDB.ts:5](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/utils/paginateItemsFromDB.ts#L5)
+[src/database/utils/paginateItemsFromDB.ts:5](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/utils/paginateItemsFromDB.ts#L5)
 
 [fake-pev-shopping](#readmemd) / api
 
@@ -706,7 +728,7 @@ Facade over database CRUD operations.
 
 #### Defined in
 
-[src/database/api.ts:150](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/api.ts#L150)
+[src/database/api.ts:150](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/api.ts#L150)
 
 ___
 
@@ -718,7 +740,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `T` | extends [`IProduct`](#interfacesmodelsiproductmd) \| `IUser` \| `IUserRole` \| [`IOrder`](#interfacesmodelsiordermd) |
+| `T` | extends [`IProduct`](#interfacesmodelsiproductmd) \| [`IOrder`](#interfacesmodelsiordermd) \| `IUser` \| `IUserRole` |
 
 #### Parameters
 
@@ -740,13 +762,13 @@ ___
 
 #### Defined in
 
-[src/database/api.ts:38](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/api.ts#L38)
+[src/database/api.ts:38](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/api.ts#L38)
 
 ___
 
 ### saveToDB
 
-▸ **saveToDB**(`modelName`, `itemData`): `Promise`<[`IProduct`](#interfacesmodelsiproductmd) \| `IUser` \| `IUserRole` \| [`IOrder`](#interfacesmodelsiordermd)\>
+▸ **saveToDB**(`modelName`, `itemData`): `Promise`<[`IProduct`](#interfacesmodelsiproductmd) \| [`IOrder`](#interfacesmodelsiordermd) \| `IUser` \| `IUserRole`\>
 
 #### Parameters
 
@@ -757,35 +779,35 @@ ___
 
 #### Returns
 
-`Promise`<[`IProduct`](#interfacesmodelsiproductmd) \| `IUser` \| `IUserRole` \| [`IOrder`](#interfacesmodelsiordermd)\>
+`Promise`<[`IProduct`](#interfacesmodelsiproductmd) \| [`IOrder`](#interfacesmodelsiordermd) \| `IUser` \| `IUserRole`\>
 
 #### Defined in
 
-[src/database/api.ts:25](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/api.ts#L25)
+[src/database/api.ts:25](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/api.ts#L25)
 
 ___
 
 ### updateOneModelInDB
 
-▸ **updateOneModelInDB**(`modelName`, `itemQuery`, `updateData`): `Promise`<``null`` \| [`IProduct`](#interfacesmodelsiproductmd) \| `IUser` \| `IUserRole` \| [`IOrder`](#interfacesmodelsiordermd)\>
+▸ **updateOneModelInDB**(`modelName`, `itemQuery`, `updateData`): `Promise`<``null`` \| [`IProduct`](#interfacesmodelsiproductmd) \| [`IOrder`](#interfacesmodelsiordermd) \| `IUser` \| `IUserRole`\>
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `modelName` | ``"Product"`` \| ``"Order"`` \| ``"User"`` \| ``"User_Role"`` |
-| `itemQuery` | `string` \| `MongooseFilterQuery`<`Pick`<[`IProduct`](#interfacesmodelsiproductmd), ``"technicalSpecs"`` \| ``"_id"`` \| ``"name"`` \| ``"url"`` \| ``"category"`` \| ``"price"`` \| ``"shortDescription"`` \| ``"images"`` \| ``"relatedProductsNames"`` \| ``"reviews"`` \| ``"availability"`` \| ``"prepareUrlField"`` \| ``"transformImagesToImagePaths"`` \| ``"validateReviewDuplicatedAuthor"`` \| ``"addReview"``\>\> \| `MongooseFilterQuery`<`Pick`<`IUser`, ``"_id"`` \| ``"login"`` \| ``"email"`` \| ``"observedProductsIDs"`` \| ``"password"`` \| ``"isConfirmed"`` \| ``"tokens"`` \| ``"accountType"`` \| ``"generateAuthToken"`` \| ``"matchPassword"`` \| ``"setSingleToken"`` \| ``"deleteSingleToken"`` \| ``"confirmUser"`` \| ``"addProductToObserved"`` \| ``"removeProductFromObserved"`` \| ``"removeAllProductsFromObserved"`` \| ``"findCurrentUserOrders"`` \| ``"findAllUsersOrders"``\>\> \| `MongooseFilterQuery`<`Pick`<`IUserRole`, ``"_id"`` \| ``"roleName"`` \| ``"owners"``\>\> \| `MongooseFilterQuery`<`Pick`<[`IOrder`](#interfacesmodelsiordermd), ``"_id"`` \| ``"receiver"`` \| ``"timestamp"`` \| ``"cost"`` \| ``"payment"`` \| ``"shipment"`` \| ``"regardingUser"`` \| ``"regardingProducts"``\>\> |
+| `itemQuery` | `string` \| `MongooseFilterQuery`<`Pick`<[`IProduct`](#interfacesmodelsiproductmd), ``"technicalSpecs"`` \| ``"_id"`` \| ``"name"`` \| ``"url"`` \| ``"category"`` \| ``"price"`` \| ``"shortDescription"`` \| ``"images"`` \| ``"relatedProductsNames"`` \| ``"reviews"`` \| ``"availability"`` \| ``"orderedUnits"`` \| ``"createdAt"`` \| ``"prepareUrlField"`` \| ``"transformImagesToImagePaths"`` \| ``"validateReviewDuplicatedAuthor"`` \| ``"addReview"``\>\> \| `MongooseFilterQuery`<`Pick`<[`IOrder`](#interfacesmodelsiordermd), ``"_id"`` \| ``"receiver"`` \| ``"timestamp"`` \| ``"cost"`` \| ``"payment"`` \| ``"shipment"`` \| ``"regardingUser"`` \| ``"regardingProducts"``\>\> \| `MongooseFilterQuery`<`Pick`<`IUser`, ``"_id"`` \| ``"login"`` \| ``"email"`` \| ``"observedProductsIDs"`` \| ``"password"`` \| ``"isConfirmed"`` \| ``"tokens"`` \| ``"accountType"`` \| ``"generateAuthToken"`` \| ``"matchPassword"`` \| ``"setSingleToken"`` \| ``"deleteSingleToken"`` \| ``"confirmUser"`` \| ``"addProductToObserved"`` \| ``"removeProductFromObserved"`` \| ``"removeAllProductsFromObserved"`` \| ``"findCurrentUserOrders"`` \| ``"findAllUsersOrders"``\>\> \| `MongooseFilterQuery`<`Pick`<`IUserRole`, ``"_id"`` \| ``"roleName"`` \| ``"owners"``\>\> |
 | `updateData` | `Object` |
 | `updateData.action` | `string` |
 | `updateData.data` | `unknown` |
 
 #### Returns
 
-`Promise`<``null`` \| [`IProduct`](#interfacesmodelsiproductmd) \| `IUser` \| `IUserRole` \| [`IOrder`](#interfacesmodelsiordermd)\>
+`Promise`<``null`` \| [`IProduct`](#interfacesmodelsiproductmd) \| [`IOrder`](#interfacesmodelsiordermd) \| `IUser` \| `IUserRole`\>
 
 #### Defined in
 
-[src/database/api.ts:110](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/api.ts#L110)
+[src/database/api.ts:110](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/api.ts#L110)
 
 [fake-pev-shopping](#readmemd) / [models](#modulesmodelsmd) / <internal\>
 
@@ -813,7 +835,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/form-data-handler.ts:7](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/form-data-handler.ts#L7)
+[src/middleware/helpers/form-data-handler.ts:7](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/form-data-handler.ts#L7)
 
 [fake-pev-shopping](#readmemd) / models
 
@@ -836,6 +858,7 @@ Groups and re-exports lower level types and values related to working with datab
 
 - [TCOLLECTION\_NAMES](#tcollection_names)
 - [TDocuments](#tdocuments)
+- [TOrderToPopulate](#tordertopopulate)
 - [TProductModel](#tproductmodel)
 - [TProductPublic](#tproductpublic)
 - [TProductToPopulate](#tproducttopopulate)
@@ -870,7 +893,7 @@ Groups and re-exports lower level types and values related to working with datab
 
 #### Defined in
 
-[src/database/models/__core-and-commons.ts:18](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/__core-and-commons.ts#L18)
+[src/database/models/__core-and-commons.ts:18](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/__core-and-commons.ts#L18)
 
 ___
 
@@ -880,7 +903,17 @@ ___
 
 #### Defined in
 
-[src/database/models/index.ts:20](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/index.ts#L20)
+[src/database/models/index.ts:20](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/index.ts#L20)
+
+___
+
+### TOrderToPopulate
+
+Ƭ **TOrderToPopulate**: [`IOrder`](#interfacesmodelsiordermd) & { `__regardingUser`: `string` ; `regardingProducts`: [`IOrder`](#interfacesmodelsiordermd)[``"regardingProducts"``][`number`] & { `__name`: `string`  }[]  }
+
+#### Defined in
+
+[src/database/models/_order.ts:169](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_order.ts#L169)
 
 ___
 
@@ -890,7 +923,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:381](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L381)
+[src/database/models/_product.ts:422](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L422)
 
 ___
 
@@ -900,7 +933,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:383](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L383)
+[src/database/models/_product.ts:424](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L424)
 
 ___
 
@@ -910,7 +943,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:388](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L388)
+[src/database/models/_product.ts:429](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L429)
 
 ___
 
@@ -924,7 +957,7 @@ ___
 
 #### Defined in
 
-[src/database/models/index.ts:21](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/index.ts#L21)
+[src/database/models/index.ts:21](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/index.ts#L21)
 
 ___
 
@@ -934,7 +967,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_user.ts:304](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_user.ts#L304)
+[src/database/models/_user.ts:304](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_user.ts#L304)
 
 ___
 
@@ -944,7 +977,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_user.ts:306](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_user.ts#L306)
+[src/database/models/_user.ts:306](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_user.ts#L306)
 
 ___
 
@@ -954,7 +987,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_user.ts:352](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_user.ts#L352)
+[src/database/models/_user.ts:352](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_user.ts#L352)
 
 ___
 
@@ -964,7 +997,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_userRole.ts:39](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_userRole.ts#L39)
+[src/database/models/_userRole.ts:39](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_userRole.ts#L39)
 
 ___
 
@@ -974,7 +1007,7 @@ ___
 
 #### Defined in
 
-[src/database/models/__core-and-commons.ts:25](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/__core-and-commons.ts#L25)
+[src/database/models/__core-and-commons.ts:25](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/__core-and-commons.ts#L25)
 
 ___
 
@@ -984,7 +1017,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_userRole.ts:49](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_userRole.ts#L49)
+[src/database/models/_userRole.ts:49](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_userRole.ts#L49)
 
 ___
 
@@ -994,7 +1027,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_user.ts:311](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_user.ts#L311)
+[src/database/models/_user.ts:311](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_user.ts#L311)
 
 ## Variables
 
@@ -1004,7 +1037,7 @@ ___
 
 #### Defined in
 
-[src/database/models/__core-and-commons.ts:12](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/__core-and-commons.ts#L12)
+[src/database/models/__core-and-commons.ts:12](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/__core-and-commons.ts#L12)
 
 ___
 
@@ -1014,7 +1047,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_order.ts:167](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_order.ts#L167)
+[src/database/models/_order.ts:168](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_order.ts#L168)
 
 ___
 
@@ -1024,7 +1057,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:380](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L380)
+[src/database/models/_product.ts:421](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L421)
 
 ___
 
@@ -1034,7 +1067,7 @@ ___
 
 #### Defined in
 
-[src/database/models/__core-and-commons.ts:21](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/__core-and-commons.ts#L21)
+[src/database/models/__core-and-commons.ts:21](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/__core-and-commons.ts#L21)
 
 ___
 
@@ -1044,7 +1077,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_user.ts:303](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_user.ts#L303)
+[src/database/models/_user.ts:303](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_user.ts#L303)
 
 ___
 
@@ -1054,7 +1087,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_userRole.ts:38](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_userRole.ts#L38)
+[src/database/models/_userRole.ts:38](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_userRole.ts#L38)
 
 ## Functions
 
@@ -1080,7 +1113,7 @@ ___
 
 #### Defined in
 
-[src/database/models/index.ts:19](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/index.ts#L19)
+[src/database/models/index.ts:19](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/index.ts#L19)
 
 ___
 
@@ -1100,7 +1133,7 @@ ___
 
 #### Defined in
 
-[src/database/models/__core-and-commons.ts:8](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/__core-and-commons.ts#L8)
+[src/database/models/__core-and-commons.ts:8](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/__core-and-commons.ts#L8)
 
 [fake-pev-shopping](#readmemd) / populate/populate
 
@@ -1146,6 +1179,7 @@ Maps default params, which are applied when regarding individual params are not 
 | Name | Type |
 | :------ | :------ |
 | `cleanAllBefore` | ``"true"`` |
+| `orders__InputPath` | ``"./initialData/orders.json"`` |
 | `product_images__FolderPath` | ``"./initialData/product-images"`` |
 | `products__InputPath` | ``"./initialData/products.json"`` |
 | `user_roles__InputPath` | ``"./initialData/user_roles.json"`` |
@@ -1153,7 +1187,7 @@ Maps default params, which are applied when regarding individual params are not 
 
 #### Defined in
 
-[src/database/populate/populate.ts:49](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/populate/populate.ts#L49)
+[src/database/populate/populate.ts:50](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/populate/populate.ts#L50)
 
 ___
 
@@ -1171,7 +1205,8 @@ Maps supported params passed via CLI.
 | :------ | :------ |
 | `CLEAN_ALL_BEFORE` | ``"cleanAllBefore"`` |
 | `EXECUTED_FROM_CLI` | ``"executedFromCLI"`` |
-| `JSON_FILE_PATH` | { `PRODUCTS`: ``"products__InputPath"`` = 'products\_\_InputPath'; `USERS`: ``"users__InputPath"`` = 'users\_\_InputPath'; `USER_ROLES`: ``"user_roles__InputPath"`` = 'user\_roles\_\_InputPath' } |
+| `JSON_FILE_PATH` | { `ORDERS`: ``"orders__InputPath"`` = 'orders\_\_InputPath'; `PRODUCTS`: ``"products__InputPath"`` = 'products\_\_InputPath'; `USERS`: ``"users__InputPath"`` = 'users\_\_InputPath'; `USER_ROLES`: ``"user_roles__InputPath"`` = 'user\_roles\_\_InputPath' } |
+| `JSON_FILE_PATH.ORDERS` | ``"orders__InputPath"`` |
 | `JSON_FILE_PATH.PRODUCTS` | ``"products__InputPath"`` |
 | `JSON_FILE_PATH.USERS` | ``"users__InputPath"`` |
 | `JSON_FILE_PATH.USER_ROLES` | ``"user_roles__InputPath"`` |
@@ -1179,7 +1214,7 @@ Maps supported params passed via CLI.
 
 #### Defined in
 
-[src/database/populate/populate.ts:35](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/populate/populate.ts#L35)
+[src/database/populate/populate.ts:35](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/populate/populate.ts#L35)
 
 ## Functions
 
@@ -1201,4 +1236,4 @@ Executes database population. May be called from other module or it's automatica
 
 #### Defined in
 
-[src/database/populate/populate.ts:130](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/populate/populate.ts#L130)
+[src/database/populate/populate.ts:134](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/populate/populate.ts#L134)

--- a/api-docs/frontend.md
+++ b/api-docs/frontend.md
@@ -62,7 +62,7 @@ fake-pev-shopping
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:27](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L27)
+[src/frontend/features/storeService.ts:27](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L27)
 
 ## Accessors
 
@@ -76,7 +76,7 @@ fake-pev-shopping
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:151](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L151)
+[src/frontend/features/storeService.ts:151](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L151)
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:147](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L147)
+[src/frontend/features/storeService.ts:147](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L147)
 
 ___
 
@@ -104,7 +104,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:135](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L135)
+[src/frontend/features/storeService.ts:135](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L135)
 
 ___
 
@@ -118,7 +118,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:143](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L143)
+[src/frontend/features/storeService.ts:143](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L143)
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:131](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L131)
+[src/frontend/features/storeService.ts:131](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L131)
 
 ___
 
@@ -146,7 +146,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:139](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L139)
+[src/frontend/features/storeService.ts:139](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L139)
 
 ## Methods
 
@@ -171,7 +171,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:48](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L48)
+[src/frontend/features/storeService.ts:48](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L48)
 
 ___
 
@@ -185,7 +185,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:119](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L119)
+[src/frontend/features/storeService.ts:119](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L119)
 
 ___
 
@@ -199,7 +199,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:127](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L127)
+[src/frontend/features/storeService.ts:127](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L127)
 
 ___
 
@@ -213,7 +213,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:43](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L43)
+[src/frontend/features/storeService.ts:43](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L43)
 
 ___
 
@@ -227,7 +227,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:89](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L89)
+[src/frontend/features/storeService.ts:89](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L89)
 
 ___
 
@@ -252,7 +252,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:69](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L69)
+[src/frontend/features/storeService.ts:69](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L69)
 
 ___
 
@@ -272,7 +272,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:96](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L96)
+[src/frontend/features/storeService.ts:96](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L96)
 
 ___
 
@@ -299,7 +299,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:102](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L102)
+[src/frontend/features/storeService.ts:102](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L102)
 
 ___
 
@@ -319,7 +319,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:123](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L123)
+[src/frontend/features/storeService.ts:123](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L123)
 
 ___
 
@@ -339,7 +339,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:39](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L39)
+[src/frontend/features/storeService.ts:39](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L39)
 
 [fake-pev-shopping](#readmemd) / [features/httpService](#modulesfeatures_httpservicemd) / [<internal\>](#modulesfeatures_httpservice_internal_md) / Ajax
 
@@ -430,7 +430,7 @@ Ajax.constructor
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:244](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L244)
+[src/frontend/features/httpService.ts:244](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L244)
 
 ## Properties
 
@@ -451,7 +451,7 @@ Ajax.constructor
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:235](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L235)
+[src/frontend/features/httpService.ts:235](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L235)
 
 ## Methods
 
@@ -465,7 +465,7 @@ Ajax.constructor
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:259](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L259)
+[src/frontend/features/httpService.ts:259](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L259)
 
 ___
 
@@ -486,7 +486,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:248](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L248)
+[src/frontend/features/httpService.ts:248](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L248)
 
 ___
 
@@ -508,7 +508,7 @@ Adds a new product.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:272](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L272)
+[src/frontend/features/httpService.ts:272](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L272)
 
 ___
 
@@ -531,7 +531,7 @@ Adds a new review to chosen product.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:409](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L409)
+[src/frontend/features/httpService.ts:409](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L409)
 
 ___
 
@@ -553,7 +553,7 @@ Adds product to observed by user, so they can more conveniently find it later.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:530](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L530)
+[src/frontend/features/httpService.ts:530](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L530)
 
 ___
 
@@ -576,7 +576,7 @@ Changes user's current password to a new one.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:523](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L523)
+[src/frontend/features/httpService.ts:523](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L523)
 
 ___
 
@@ -598,7 +598,7 @@ Confirms a newly registered user via token received on their email.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:502](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L502)
+[src/frontend/features/httpService.ts:502](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L502)
 
 ___
 
@@ -620,7 +620,7 @@ Delets a product via it's name.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:416](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L416)
+[src/frontend/features/httpService.ts:416](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L416)
 
 ___
 
@@ -636,7 +636,7 @@ Gets orders of all client users.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:437](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L437)
+[src/frontend/features/httpService.ts:437](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L437)
 
 ___
 
@@ -652,7 +652,7 @@ Gets info about currently logged in user via it's ID taken from app's state.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:423](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L423)
+[src/frontend/features/httpService.ts:423](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L423)
 
 ___
 
@@ -668,7 +668,7 @@ Gets orders of currently logged in client user.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:430](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L430)
+[src/frontend/features/httpService.ts:430](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L430)
 
 ___
 
@@ -684,7 +684,7 @@ Retrieves all observed products by user.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:551](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L551)
+[src/frontend/features/httpService.ts:551](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L551)
 
 ___
 
@@ -706,7 +706,7 @@ Gets product by it's URL - mostly useful for retrieving product from browser's a
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:363](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L363)
+[src/frontend/features/httpService.ts:363](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L363)
 
 ___
 
@@ -722,7 +722,7 @@ Gets categories of all products.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:379](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L379)
+[src/frontend/features/httpService.ts:379](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L379)
 
 ___
 
@@ -745,7 +745,7 @@ Gets products according to optional constraints like: name, price, pagination et
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:279](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L279)
+[src/frontend/features/httpService.ts:279](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L279)
 
 ___
 
@@ -765,7 +765,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:323](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L323)
+[src/frontend/features/httpService.ts:323](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L323)
 
 ___
 
@@ -789,7 +789,7 @@ Gets products by a single name - mostly useful for search feature.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:350](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L350)
+[src/frontend/features/httpService.ts:350](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L350)
 
 ___
 
@@ -811,7 +811,7 @@ Gets products by list of names - mostly useful for retrieving related products o
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:334](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L334)
+[src/frontend/features/httpService.ts:334](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L334)
 
 ___
 
@@ -827,7 +827,7 @@ Gets technical specifications of all products.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:386](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L386)
+[src/frontend/features/httpService.ts:386](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L386)
 
 ___
 
@@ -843,7 +843,7 @@ Gets all user roles.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:488](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L488)
+[src/frontend/features/httpService.ts:488](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L488)
 
 ___
 
@@ -865,7 +865,7 @@ Loggs out user from all sessions; current session can be preserved if `preseveCu
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:481](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L481)
+[src/frontend/features/httpService.ts:481](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L481)
 
 ___
 
@@ -889,7 +889,7 @@ Logs in user based on their login and password credentials.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:451](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L451)
+[src/frontend/features/httpService.ts:451](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L451)
 
 ___
 
@@ -905,7 +905,7 @@ Loggs out user from current session.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:474](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L474)
+[src/frontend/features/httpService.ts:474](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L474)
 
 ___
 
@@ -927,7 +927,7 @@ Starts the process of making a new purchase according to given order details.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:444](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L444)
+[src/frontend/features/httpService.ts:444](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L444)
 
 ___
 
@@ -950,7 +950,7 @@ Modifies product.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:395](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L395)
+[src/frontend/features/httpService.ts:395](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L395)
 
 ___
 
@@ -972,7 +972,7 @@ Registers a new user according to provided credentials.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:495](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L495)
+[src/frontend/features/httpService.ts:495](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L495)
 
 ___
 
@@ -988,7 +988,7 @@ Removes all products from observed by user.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:544](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L544)
+[src/frontend/features/httpService.ts:544](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L544)
 
 ___
 
@@ -1010,7 +1010,7 @@ Removes product from observed by user.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:537](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L537)
+[src/frontend/features/httpService.ts:537](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L537)
 
 ___
 
@@ -1032,7 +1032,7 @@ Resends registration confirmation email.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:509](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L509)
+[src/frontend/features/httpService.ts:509](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L509)
 
 ___
 
@@ -1054,7 +1054,7 @@ Resends (repeats) resetting user password via it's email.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:467](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L467)
+[src/frontend/features/httpService.ts:467](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L467)
 
 ___
 
@@ -1076,7 +1076,7 @@ Resets user password via it's email.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:460](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L460)
+[src/frontend/features/httpService.ts:460](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L460)
 
 ___
 
@@ -1099,7 +1099,7 @@ Sets a new password for user - mostly after reseting password.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:516](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L516)
+[src/frontend/features/httpService.ts:516](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L516)
 
 [fake-pev-shopping](#readmemd) / [features/storageService](#modulesfeatures_storageservicemd) / [<internal\>](#modulesfeatures_storageservice_internal_md) / StorageService
 
@@ -1147,7 +1147,7 @@ Sets a new password for user - mostly after reseting password.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:18](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L18)
+[src/frontend/features/storageService.ts:18](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L18)
 
 ## Properties
 
@@ -1157,7 +1157,7 @@ Sets a new password for user - mostly after reseting password.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:16](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L16)
+[src/frontend/features/storageService.ts:16](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L16)
 
 ## Methods
 
@@ -1173,7 +1173,7 @@ Already parsed (from JSON) stored value.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:42](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L42)
+[src/frontend/features/storageService.ts:42](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L42)
 
 ___
 
@@ -1189,7 +1189,7 @@ Removes a values.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:54](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L54)
+[src/frontend/features/storageService.ts:54](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L54)
 
 ___
 
@@ -1213,7 +1213,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:26](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L26)
+[src/frontend/features/storageService.ts:26](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L26)
 
 [fake-pev-shopping](#readmemd) / [features/storageService](#modulesfeatures_storageservicemd) / [<internal\>](#modulesfeatures_storageservice_internal_md) / UserAccount
 
@@ -1261,7 +1261,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:70](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L70)
+[src/frontend/features/storageService.ts:70](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L70)
 
 ## Properties
 
@@ -1275,7 +1275,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:16](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L16)
+[src/frontend/features/storageService.ts:16](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L16)
 
 ## Methods
 
@@ -1295,7 +1295,7 @@ Already parsed (from JSON) stored value.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:42](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L42)
+[src/frontend/features/storageService.ts:42](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L42)
 
 ___
 
@@ -1315,7 +1315,7 @@ Removes a values.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:54](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L54)
+[src/frontend/features/storageService.ts:54](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L54)
 
 ___
 
@@ -1342,7 +1342,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:74](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L74)
+[src/frontend/features/storageService.ts:74](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L74)
 
 [fake-pev-shopping](#readmemd) / [features/storageService](#modulesfeatures_storageservicemd) / [<internal\>](#modulesfeatures_storageservice_internal_md) / UserAuthToken
 
@@ -1390,7 +1390,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:80](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L80)
+[src/frontend/features/storageService.ts:80](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L80)
 
 ## Properties
 
@@ -1404,7 +1404,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:16](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L16)
+[src/frontend/features/storageService.ts:16](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L16)
 
 ## Methods
 
@@ -1424,7 +1424,7 @@ Already parsed (from JSON) stored value.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:42](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L42)
+[src/frontend/features/storageService.ts:42](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L42)
 
 ___
 
@@ -1444,7 +1444,7 @@ Removes a values.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:54](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L54)
+[src/frontend/features/storageService.ts:54](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L54)
 
 ___
 
@@ -1471,7 +1471,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:84](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L84)
+[src/frontend/features/storageService.ts:84](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L84)
 
 [fake-pev-shopping](#readmemd) / [features/storageService](#modulesfeatures_storageservicemd) / [<internal\>](#modulesfeatures_storageservice_internal_md) / UserCart
 
@@ -1519,7 +1519,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:60](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L60)
+[src/frontend/features/storageService.ts:60](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L60)
 
 ## Properties
 
@@ -1533,7 +1533,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:16](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L16)
+[src/frontend/features/storageService.ts:16](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L16)
 
 ## Methods
 
@@ -1553,7 +1553,7 @@ Already parsed (from JSON) stored value.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:42](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L42)
+[src/frontend/features/storageService.ts:42](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L42)
 
 ___
 
@@ -1573,7 +1573,7 @@ Removes a values.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:54](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L54)
+[src/frontend/features/storageService.ts:54](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L54)
 
 ___
 
@@ -1600,7 +1600,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:64](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L64)
+[src/frontend/features/storageService.ts:64](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L64)
 
 [fake-pev-shopping](#readmemd) / [components/pages/\_routes](#modulescomponents_pages__routesmd) / [<internal\>](#modulescomponents_pages__routes_internal_md) / IUserCart
 
@@ -1624,7 +1624,7 @@ depending on result of calling `checkIfShouldRemove`.
 
 #### Defined in
 
-[commons/types.ts:61](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L61)
+[commons/types.ts:61](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L61)
 
 ___
 
@@ -1634,7 +1634,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:68](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L68)
+[commons/types.ts:68](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L68)
 
 ___
 
@@ -1644,7 +1644,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:69](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L69)
+[commons/types.ts:69](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L69)
 
 [fake-pev-shopping](#readmemd) / [features/httpService](#modulesfeatures_httpservicemd) / [<internal\>](#modulesfeatures_httpservice_internal_md) / ICustomResExt
 
@@ -1668,7 +1668,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:604](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L604)
+[src/frontend/features/httpService.ts:604](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L604)
 
 ___
 
@@ -1678,7 +1678,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:605](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L605)
+[src/frontend/features/httpService.ts:605](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L605)
 
 ___
 
@@ -1688,7 +1688,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:603](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L603)
+[src/frontend/features/httpService.ts:603](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L603)
 
 [fake-pev-shopping](#readmemd) / [features/httpService](#modulesfeatures_httpservicemd) / [<internal\>](#modulesfeatures_httpservice_internal_md) / IEmbracedResponse
 
@@ -1720,7 +1720,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:11](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L11)
+[src/middleware/helpers/middleware-response-wrapper.ts:11](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L11)
 
 ___
 
@@ -1730,7 +1730,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:14](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L14)
+[src/middleware/helpers/middleware-response-wrapper.ts:14](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L14)
 
 ___
 
@@ -1740,7 +1740,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:15](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L15)
+[src/middleware/helpers/middleware-response-wrapper.ts:15](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L15)
 
 ___
 
@@ -1750,7 +1750,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:13](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L13)
+[src/middleware/helpers/middleware-response-wrapper.ts:13](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L13)
 
 ___
 
@@ -1760,7 +1760,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:12](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L12)
+[src/middleware/helpers/middleware-response-wrapper.ts:12](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L12)
 
 [fake-pev-shopping](#readmemd) / [features/httpService](#modulesfeatures_httpservicemd) / [<internal\>](#modulesfeatures_httpservice_internal_md) / IOrderPayload
 
@@ -1791,7 +1791,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:78](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L78)
+[commons/types.ts:78](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L78)
 
 ___
 
@@ -1801,7 +1801,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:85](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L85)
+[commons/types.ts:85](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L85)
 
 ___
 
@@ -1819,7 +1819,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:73](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L73)
+[commons/types.ts:73](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L73)
 
 ___
 
@@ -1836,7 +1836,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:81](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L81)
+[commons/types.ts:81](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L81)
 
 [fake-pev-shopping](#readmemd) / [features/httpService](#modulesfeatures_httpservicemd) / [<internal\>](#modulesfeatures_httpservice_internal_md) / IProduct
 
@@ -1856,8 +1856,10 @@ ___
 
 - [availability](#availability)
 - [category](#category)
+- [createdAt](#createdat)
 - [images](#images)
 - [name](#name)
+- [orderedUnits](#orderedunits)
 - [price](#price)
 - [relatedProductsNames](#relatedproductsnames)
 - [reviews](#reviews)
@@ -1880,7 +1882,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:458](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L458)
+[src/database/models/_product.ts:500](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L500)
 
 ___
 
@@ -1890,7 +1892,17 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:447](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L447)
+[src/database/models/_product.ts:489](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L489)
+
+___
+
+### createdAt
+
+• **createdAt**: `number`
+
+#### Defined in
+
+[src/database/models/_product.ts:502](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L502)
 
 ___
 
@@ -1900,7 +1912,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:455](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L455)
+[src/database/models/_product.ts:497](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L497)
 
 ___
 
@@ -1910,7 +1922,17 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:445](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L445)
+[src/database/models/_product.ts:487](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L487)
+
+___
+
+### orderedUnits
+
+• **orderedUnits**: `number`
+
+#### Defined in
+
+[src/database/models/_product.ts:501](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L501)
 
 ___
 
@@ -1920,7 +1942,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:448](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L448)
+[src/database/models/_product.ts:490](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L490)
 
 ___
 
@@ -1930,7 +1952,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:456](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L456)
+[src/database/models/_product.ts:498](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L498)
 
 ___
 
@@ -1940,7 +1962,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:457](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L457)
+[src/database/models/_product.ts:499](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L499)
 
 ___
 
@@ -1950,7 +1972,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:449](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L449)
+[src/database/models/_product.ts:491](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L491)
 
 ___
 
@@ -1960,7 +1982,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:450](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L450)
+[src/database/models/_product.ts:492](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L492)
 
 ___
 
@@ -1970,7 +1992,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:446](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L446)
+[src/database/models/_product.ts:488](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L488)
 
 ## Methods
 
@@ -1991,7 +2013,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:465](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L465)
+[src/database/models/_product.ts:509](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L509)
 
 ___
 
@@ -2005,7 +2027,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:460](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L460)
+[src/database/models/_product.ts:504](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L504)
 
 ___
 
@@ -2019,7 +2041,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:461](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L461)
+[src/database/models/_product.ts:505](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L505)
 
 ___
 
@@ -2039,7 +2061,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:462](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L462)
+[src/database/models/_product.ts:506](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L506)
 
 [fake-pev-shopping](#readmemd) / [features/httpService](#modulesfeatures_httpservicemd) / [<internal\>](#modulesfeatures_httpservice_internal_md) / IProductInOrder
 
@@ -2063,7 +2085,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:28](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L28)
+[commons/types.ts:28](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L28)
 
 ___
 
@@ -2073,7 +2095,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:30](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L30)
+[commons/types.ts:30](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L30)
 
 ___
 
@@ -2083,7 +2105,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:29](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L29)
+[commons/types.ts:29](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L29)
 
 [fake-pev-shopping](#readmemd) / [components/pages/\_routes](#modulescomponents_pages__routesmd) / <internal\>
 
@@ -2113,7 +2135,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_user.ts:306](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_user.ts#L306)
+[src/database/models/_user.ts:306](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_user.ts#L306)
 
 [fake-pev-shopping](#readmemd) / components/pages/\_routes
 
@@ -2170,7 +2192,7 @@ Encapsulates routing paths and methods (such as helpers and guards).
 
 #### Defined in
 
-[src/frontend/components/pages/_routes.ts:23](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/pages/_routes.ts#L23)
+[src/frontend/components/pages/_routes.ts:23](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/pages/_routes.ts#L23)
 
 ___
 
@@ -2192,7 +2214,7 @@ ___
 
 #### Defined in
 
-[src/frontend/components/pages/_routes.ts:64](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/pages/_routes.ts#L64)
+[src/frontend/components/pages/_routes.ts:64](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/pages/_routes.ts#L64)
 
 ## Functions
 
@@ -2219,7 +2241,7 @@ ___
 
 #### Defined in
 
-[src/frontend/components/pages/_routes.ts:109](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/pages/_routes.ts#L109)
+[src/frontend/components/pages/_routes.ts:109](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/pages/_routes.ts#L109)
 
 [fake-pev-shopping](#readmemd) / [components/utils/bodyObserver](#modulescomponents_utils_bodyobservermd) / <internal\>
 
@@ -2261,7 +2283,7 @@ ___
 
 #### Defined in
 
-[src/frontend/components/utils/bodyObserver.tsx:7](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/bodyObserver.tsx#L7)
+[src/frontend/components/utils/bodyObserver.tsx:7](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/bodyObserver.tsx#L7)
 
 [fake-pev-shopping](#readmemd) / components/utils/bodyObserver
 
@@ -2303,7 +2325,7 @@ subscriptionID, which lets unsubscribing `callback` later.
 
 #### Defined in
 
-[src/frontend/components/utils/bodyObserver.tsx:26](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/bodyObserver.tsx#L26)
+[src/frontend/components/utils/bodyObserver.tsx:26](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/bodyObserver.tsx#L26)
 
 ___
 
@@ -2325,7 +2347,7 @@ Unsubscribes previously subscribed `callback` (via it's ID) from `<body>` style 
 
 #### Defined in
 
-[src/frontend/components/utils/bodyObserver.tsx:36](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/bodyObserver.tsx#L36)
+[src/frontend/components/utils/bodyObserver.tsx:36](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/bodyObserver.tsx#L36)
 
 [fake-pev-shopping](#readmemd) / components/utils/flexibleList
 
@@ -2357,7 +2379,7 @@ Flexible list component, which allows adding, editing and deleting it's items in
 
 #### Defined in
 
-[src/frontend/components/utils/flexibleList.jsx:72](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/flexibleList.jsx#L72)
+[src/frontend/components/utils/flexibleList.jsx:72](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/flexibleList.jsx#L72)
 
 [fake-pev-shopping](#readmemd) / components/utils/pagination
 
@@ -2387,7 +2409,7 @@ Flexible list component, which allows adding, editing and deleting it's items in
 
 #### Defined in
 
-[src/frontend/components/utils/pagination.jsx:20](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/pagination.jsx#L20)
+[src/frontend/components/utils/pagination.jsx:20](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/pagination.jsx#L20)
 
 [fake-pev-shopping](#readmemd) / components/utils/pevElements
 
@@ -2426,7 +2448,7 @@ Facade over commonly used MUI and native HTML elements.
 
 #### Defined in
 
-[src/frontend/components/utils/pevElements.jsx:48](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/pevElements.jsx#L48)
+[src/frontend/components/utils/pevElements.jsx:56](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/pevElements.jsx#L56)
 
 ___
 
@@ -2436,7 +2458,7 @@ ___
 
 #### Defined in
 
-[src/frontend/components/utils/pevElements.jsx:181](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/pevElements.jsx#L181)
+[src/frontend/components/utils/pevElements.jsx:189](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/pevElements.jsx#L189)
 
 ___
 
@@ -2446,7 +2468,7 @@ ___
 
 #### Defined in
 
-[src/frontend/components/utils/pevElements.jsx:90](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/pevElements.jsx#L90)
+[src/frontend/components/utils/pevElements.jsx:98](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/pevElements.jsx#L98)
 
 ___
 
@@ -2456,7 +2478,7 @@ ___
 
 #### Defined in
 
-[src/frontend/components/utils/pevElements.jsx:189](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/pevElements.jsx#L189)
+[src/frontend/components/utils/pevElements.jsx:197](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/pevElements.jsx#L197)
 
 ___
 
@@ -2466,7 +2488,7 @@ ___
 
 #### Defined in
 
-[src/frontend/components/utils/pevElements.jsx:228](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/pevElements.jsx#L228)
+[src/frontend/components/utils/pevElements.jsx:236](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/pevElements.jsx#L236)
 
 ___
 
@@ -2476,7 +2498,7 @@ ___
 
 #### Defined in
 
-[src/frontend/components/utils/pevElements.jsx:66](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/pevElements.jsx#L66)
+[src/frontend/components/utils/pevElements.jsx:74](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/pevElements.jsx#L74)
 
 ___
 
@@ -2486,7 +2508,7 @@ ___
 
 #### Defined in
 
-[src/frontend/components/utils/pevElements.jsx:363](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/pevElements.jsx#L363)
+[src/frontend/components/utils/pevElements.jsx:371](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/pevElements.jsx#L371)
 
 ___
 
@@ -2496,7 +2518,7 @@ ___
 
 #### Defined in
 
-[src/frontend/components/utils/pevElements.jsx:98](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/pevElements.jsx#L98)
+[src/frontend/components/utils/pevElements.jsx:106](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/pevElements.jsx#L106)
 
 ___
 
@@ -2506,7 +2528,7 @@ ___
 
 #### Defined in
 
-[src/frontend/components/utils/pevElements.jsx:82](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/pevElements.jsx#L82)
+[src/frontend/components/utils/pevElements.jsx:90](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/pevElements.jsx#L90)
 
 ___
 
@@ -2516,7 +2538,7 @@ ___
 
 #### Defined in
 
-[src/frontend/components/utils/pevElements.jsx:242](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/pevElements.jsx#L242)
+[src/frontend/components/utils/pevElements.jsx:250](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/pevElements.jsx#L250)
 
 ___
 
@@ -2526,7 +2548,7 @@ ___
 
 #### Defined in
 
-[src/frontend/components/utils/pevElements.jsx:387](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/pevElements.jsx#L387)
+[src/frontend/components/utils/pevElements.jsx:395](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/pevElements.jsx#L395)
 
 ___
 
@@ -2536,7 +2558,7 @@ ___
 
 #### Defined in
 
-[src/frontend/components/utils/pevElements.jsx:185](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/pevElements.jsx#L185)
+[src/frontend/components/utils/pevElements.jsx:193](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/pevElements.jsx#L193)
 
 ___
 
@@ -2546,7 +2568,7 @@ ___
 
 #### Defined in
 
-[src/frontend/components/utils/pevElements.jsx:290](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/pevElements.jsx#L290)
+[src/frontend/components/utils/pevElements.jsx:298](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/pevElements.jsx#L298)
 
 ## Functions
 
@@ -2566,7 +2588,7 @@ ___
 
 #### Defined in
 
-[src/frontend/components/utils/pevElements.jsx:220](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/pevElements.jsx#L220)
+[src/frontend/components/utils/pevElements.jsx:228](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/pevElements.jsx#L228)
 
 ___
 
@@ -2586,7 +2608,7 @@ ___
 
 #### Defined in
 
-[src/frontend/components/utils/pevElements.jsx:106](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/pevElements.jsx#L106)
+[src/frontend/components/utils/pevElements.jsx:114](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/pevElements.jsx#L114)
 
 [fake-pev-shopping](#readmemd) / components/utils/popup
 
@@ -2614,7 +2636,7 @@ Generic error popup component is hooked on [HttpService](#classesfeatures_httpse
 
 #### Defined in
 
-[src/frontend/components/utils/popup.jsx:57](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/popup.jsx#L57)
+[src/frontend/components/utils/popup.jsx:57](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/popup.jsx#L57)
 
 ___
 
@@ -2632,7 +2654,7 @@ ___
 
 #### Defined in
 
-[src/frontend/components/utils/popup.jsx:16](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/popup.jsx#L16)
+[src/frontend/components/utils/popup.jsx:16](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/popup.jsx#L16)
 
 ## Functions
 
@@ -2652,7 +2674,7 @@ ___
 
 #### Defined in
 
-[src/frontend/components/utils/popup.jsx:92](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/popup.jsx#L92)
+[src/frontend/components/utils/popup.jsx:92](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/popup.jsx#L92)
 
 ___
 
@@ -2680,7 +2702,7 @@ Factory for popup's default closing button.
 
 #### Defined in
 
-[src/frontend/components/utils/popup.jsx:25](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/popup.jsx#L25)
+[src/frontend/components/utils/popup.jsx:25](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/popup.jsx#L25)
 
 [fake-pev-shopping](#readmemd) / components/utils/ratingWidget
 
@@ -2710,7 +2732,7 @@ Factory for popup's default closing button.
 
 #### Defined in
 
-[src/frontend/components/utils/ratingWidget.jsx:29](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/ratingWidget.jsx#L29)
+[src/frontend/components/utils/ratingWidget.jsx:29](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/ratingWidget.jsx#L29)
 
 [fake-pev-shopping](#readmemd) / components/utils/scroller
 
@@ -2740,7 +2762,7 @@ Factory for popup's default closing button.
 
 #### Defined in
 
-[src/frontend/components/utils/scroller.jsx:94](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/components/utils/scroller.jsx#L94)
+[src/frontend/components/utils/scroller.jsx:94](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/components/utils/scroller.jsx#L94)
 
 [fake-pev-shopping](#readmemd) / contexts/rwd-layout
 
@@ -2773,7 +2795,7 @@ Observes DOM viewport changes and emits information about the currently establis
 
 #### Defined in
 
-[src/frontend/contexts/rwd-layout.tsx:79](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/contexts/rwd-layout.tsx#L79)
+[src/frontend/contexts/rwd-layout.tsx:79](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/contexts/rwd-layout.tsx#L79)
 
 ___
 
@@ -2787,7 +2809,7 @@ ___
 
 #### Defined in
 
-[src/frontend/contexts/rwd-layout.tsx:83](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/contexts/rwd-layout.tsx#L83)
+[src/frontend/contexts/rwd-layout.tsx:83](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/contexts/rwd-layout.tsx#L83)
 
 [fake-pev-shopping](#readmemd) / [features/httpService](#modulesfeatures_httpservicemd) / <internal\>
 
@@ -2827,7 +2849,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/api-products-specs-mapper.ts:4](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/api-products-specs-mapper.ts#L4)
+[src/middleware/helpers/api-products-specs-mapper.ts:4](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/api-products-specs-mapper.ts#L4)
 
 ___
 
@@ -2845,7 +2867,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/api-products-specs-mapper.ts:8](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/api-products-specs-mapper.ts#L8)
+[src/middleware/helpers/api-products-specs-mapper.ts:8](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/api-products-specs-mapper.ts#L8)
 
 ___
 
@@ -2862,7 +2884,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:88](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L88)
+[commons/types.ts:88](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L88)
 
 ___
 
@@ -2879,7 +2901,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/api-products-specs-mapper.ts:13](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/api-products-specs-mapper.ts#L13)
+[src/middleware/helpers/api-products-specs-mapper.ts:13](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/api-products-specs-mapper.ts#L13)
 
 ___
 
@@ -2903,7 +2925,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:565](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L565)
+[src/frontend/features/httpService.ts:565](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L565)
 
 ___
 
@@ -2913,7 +2935,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_user.ts:352](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_user.ts#L352)
+[src/database/models/_user.ts:352](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_user.ts#L352)
 
 [fake-pev-shopping](#readmemd) / features/httpService
 
@@ -2943,7 +2965,7 @@ Recognize HTTP responses kinds.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:596](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L596)
+[src/frontend/features/httpService.ts:596](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L596)
 
 ___
 
@@ -2953,7 +2975,7 @@ ___
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:610](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L610)
+[src/frontend/features/httpService.ts:610](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L610)
 
 ___
 
@@ -2975,7 +2997,7 @@ that returns certain status.
 
 #### Defined in
 
-[src/frontend/features/httpService.ts:560](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/httpService.ts#L560)
+[src/frontend/features/httpService.ts:560](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/httpService.ts#L560)
 
 [fake-pev-shopping](#readmemd) / [features/storageService](#modulesfeatures_storageservicemd) / <internal\>
 
@@ -3004,7 +3026,7 @@ that returns certain status.
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:9](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L9)
+[src/frontend/features/storageService.ts:9](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L9)
 
 [fake-pev-shopping](#readmemd) / features/storageService
 
@@ -3040,7 +3062,7 @@ Manipulating storage data API for various contexts, such as `UserCart` or `UserA
 
 #### Defined in
 
-[src/frontend/features/storageService.ts:14](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storageService.ts#L14)
+[src/frontend/features/storageService.ts:14](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storageService.ts#L14)
 
 [fake-pev-shopping](#readmemd) / features/storeService
 
@@ -3064,7 +3086,7 @@ Manipulating storage data API for various contexts, such as `UserCart` or `UserA
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:185](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L185)
+[src/frontend/features/storeService.ts:185](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L185)
 
 ## Variables
 
@@ -3074,7 +3096,7 @@ Manipulating storage data API for various contexts, such as `UserCart` or `UserA
 
 #### Defined in
 
-[src/frontend/features/storeService.ts:177](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/storeService.ts#L177)
+[src/frontend/features/storeService.ts:177](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/storeService.ts#L177)
 
 [fake-pev-shopping](#readmemd) / features/userSessionService
 
@@ -3103,4 +3125,4 @@ Manipulating storage data API for various contexts, such as `UserCart` or `UserA
 
 #### Defined in
 
-[src/frontend/features/userSessionService.ts:12](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/frontend/features/userSessionService.ts#L12)
+[src/frontend/features/userSessionService.ts:12](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/frontend/features/userSessionService.ts#L12)

--- a/api-docs/middleware.md
+++ b/api-docs/middleware.md
@@ -47,7 +47,7 @@ fake-pev-shopping
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:11](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L11)
+[src/middleware/helpers/middleware-response-wrapper.ts:11](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L11)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:14](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L14)
+[src/middleware/helpers/middleware-response-wrapper.ts:14](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L14)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:15](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L15)
+[src/middleware/helpers/middleware-response-wrapper.ts:15](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L15)
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:13](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L13)
+[src/middleware/helpers/middleware-response-wrapper.ts:13](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L13)
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:12](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L12)
+[src/middleware/helpers/middleware-response-wrapper.ts:12](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L12)
 
 [fake-pev-shopping](#readmemd) / [routes/api-users](#modulesroutes_api_usersmd) / [<internal\>](#modulesroutes_api_users_internal_md) / IOrder
 
@@ -131,7 +131,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_order.ts:180](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_order.ts#L180)
+[src/database/models/_order.ts:185](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_order.ts#L185)
 
 ___
 
@@ -147,7 +147,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_order.ts:185](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_order.ts#L185)
+[src/database/models/_order.ts:190](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_order.ts#L190)
 
 ___
 
@@ -169,7 +169,7 @@ Pick.receiver
 
 #### Defined in
 
-[src/database/models/_order.ts:179](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_order.ts#L179)
+[src/database/models/_order.ts:184](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_order.ts#L184)
 
 ___
 
@@ -179,7 +179,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_order.ts:193](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_order.ts#L193)
+[src/database/models/_order.ts:198](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_order.ts#L198)
 
 ___
 
@@ -189,7 +189,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_order.ts:192](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_order.ts#L192)
+[src/database/models/_order.ts:197](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_order.ts#L197)
 
 ___
 
@@ -206,7 +206,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_order.ts:188](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_order.ts#L188)
+[src/database/models/_order.ts:193](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_order.ts#L193)
 
 ___
 
@@ -216,7 +216,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_order.ts:178](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_order.ts#L178)
+[src/database/models/_order.ts:183](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_order.ts#L183)
 
 [fake-pev-shopping](#readmemd) / [routes/api-users](#modulesroutes_api_usersmd) / [<internal\>](#modulesroutes_api_users_internal_md) / IOrderPayload
 
@@ -247,7 +247,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:78](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L78)
+[commons/types.ts:78](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L78)
 
 ___
 
@@ -257,7 +257,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:85](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L85)
+[commons/types.ts:85](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L85)
 
 ___
 
@@ -275,7 +275,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:73](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L73)
+[commons/types.ts:73](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L73)
 
 ___
 
@@ -292,7 +292,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:81](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L81)
+[commons/types.ts:81](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L81)
 
 [fake-pev-shopping](#readmemd) / [routes/api-users](#modulesroutes_api_usersmd) / [<internal\>](#modulesroutes_api_users_internal_md) / IProduct
 
@@ -312,8 +312,10 @@ ___
 
 - [availability](#availability)
 - [category](#category)
+- [createdAt](#createdat)
 - [images](#images)
 - [name](#name)
+- [orderedUnits](#orderedunits)
 - [price](#price)
 - [relatedProductsNames](#relatedproductsnames)
 - [reviews](#reviews)
@@ -336,7 +338,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:458](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L458)
+[src/database/models/_product.ts:500](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L500)
 
 ___
 
@@ -346,7 +348,17 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:447](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L447)
+[src/database/models/_product.ts:489](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L489)
+
+___
+
+### createdAt
+
+• **createdAt**: `number`
+
+#### Defined in
+
+[src/database/models/_product.ts:502](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L502)
 
 ___
 
@@ -356,7 +368,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:455](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L455)
+[src/database/models/_product.ts:497](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L497)
 
 ___
 
@@ -366,7 +378,17 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:445](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L445)
+[src/database/models/_product.ts:487](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L487)
+
+___
+
+### orderedUnits
+
+• **orderedUnits**: `number`
+
+#### Defined in
+
+[src/database/models/_product.ts:501](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L501)
 
 ___
 
@@ -376,7 +398,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:448](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L448)
+[src/database/models/_product.ts:490](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L490)
 
 ___
 
@@ -386,7 +408,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:456](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L456)
+[src/database/models/_product.ts:498](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L498)
 
 ___
 
@@ -396,7 +418,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:457](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L457)
+[src/database/models/_product.ts:499](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L499)
 
 ___
 
@@ -406,7 +428,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:449](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L449)
+[src/database/models/_product.ts:491](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L491)
 
 ___
 
@@ -416,7 +438,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:450](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L450)
+[src/database/models/_product.ts:492](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L492)
 
 ___
 
@@ -426,7 +448,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:446](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L446)
+[src/database/models/_product.ts:488](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L488)
 
 ## Methods
 
@@ -447,7 +469,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:465](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L465)
+[src/database/models/_product.ts:509](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L509)
 
 ___
 
@@ -461,7 +483,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:460](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L460)
+[src/database/models/_product.ts:504](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L504)
 
 ___
 
@@ -475,7 +497,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:461](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L461)
+[src/database/models/_product.ts:505](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L505)
 
 ___
 
@@ -495,7 +517,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_product.ts:462](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_product.ts#L462)
+[src/database/models/_product.ts:506](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_product.ts#L506)
 
 [fake-pev-shopping](#readmemd) / [routes/api-users](#modulesroutes_api_usersmd) / [<internal\>](#modulesroutes_api_users_internal_md) / IProductInOrder
 
@@ -519,7 +541,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:28](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L28)
+[commons/types.ts:28](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L28)
 
 ___
 
@@ -529,7 +551,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:30](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L30)
+[commons/types.ts:30](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L30)
 
 ___
 
@@ -539,7 +561,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:29](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L29)
+[commons/types.ts:29](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L29)
 
 [fake-pev-shopping](#readmemd) / [features/auth](#modulesfeatures_authmd) / <internal\>
 
@@ -587,7 +609,7 @@ ___
 
 #### Defined in
 
-[src/middleware/features/auth.ts:38](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/features/auth.ts#L38)
+[src/middleware/features/auth.ts:38](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/features/auth.ts#L38)
 
 ___
 
@@ -601,7 +623,7 @@ ___
 
 #### Defined in
 
-[src/middleware/features/auth.ts:96](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/features/auth.ts#L96)
+[src/middleware/features/auth.ts:96](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/features/auth.ts#L96)
 
 ___
 
@@ -622,7 +644,7 @@ ___
 
 #### Defined in
 
-[src/middleware/features/auth.ts:22](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/features/auth.ts#L22)
+[src/middleware/features/auth.ts:22](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/features/auth.ts#L22)
 
 ___
 
@@ -642,7 +664,7 @@ ___
 
 #### Defined in
 
-[src/middleware/features/auth.ts:30](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/features/auth.ts#L30)
+[src/middleware/features/auth.ts:30](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/features/auth.ts#L30)
 
 ___
 
@@ -662,7 +684,7 @@ ___
 
 #### Defined in
 
-[src/middleware/features/auth.ts:26](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/features/auth.ts#L26)
+[src/middleware/features/auth.ts:26](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/features/auth.ts#L26)
 
 ___
 
@@ -696,7 +718,7 @@ ___
 
 #### Defined in
 
-[src/middleware/features/auth.ts:80](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/features/auth.ts#L80)
+[src/middleware/features/auth.ts:80](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/features/auth.ts#L80)
 
 ___
 
@@ -716,7 +738,7 @@ ___
 
 #### Defined in
 
-[src/middleware/features/auth.ts:34](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/features/auth.ts#L34)
+[src/middleware/features/auth.ts:34](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/features/auth.ts#L34)
 
 [fake-pev-shopping](#readmemd) / helpers/mailer
 
@@ -740,7 +762,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/mailer.ts:51](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/mailer.ts#L51)
+[src/middleware/helpers/mailer.ts:51](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/mailer.ts#L51)
 
 ## Functions
 
@@ -762,7 +784,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/mailer.ts:55](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/mailer.ts#L55)
+[src/middleware/helpers/mailer.ts:55](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/mailer.ts#L55)
 
 [fake-pev-shopping](#readmemd) / [helpers/middleware-error-handler](#moduleshelpers_middleware_error_handlermd) / <internal\>
 
@@ -800,7 +822,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/middleware-error-handler.ts:10](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-error-handler.ts#L10)
+[src/middleware/helpers/middleware-error-handler.ts:10](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-error-handler.ts#L10)
 
 [fake-pev-shopping](#readmemd) / helpers/middleware-error-handler
 
@@ -834,7 +856,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/middleware-error-handler.ts:14](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-error-handler.ts#L14)
+[src/middleware/helpers/middleware-error-handler.ts:14](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-error-handler.ts#L14)
 
 [fake-pev-shopping](#readmemd) / [helpers/middleware-response-wrapper](#moduleshelpers_middleware_response_wrappermd) / <internal\>
 
@@ -861,7 +883,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:53](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L53)
+[commons/types.ts:53](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L53)
 
 ___
 
@@ -871,7 +893,7 @@ ___
 
 #### Defined in
 
-[commons/types.ts:47](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/commons/types.ts#L47)
+[commons/types.ts:47](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/commons/types.ts#L47)
 
 ## Variables
 
@@ -881,7 +903,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:19](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L19)
+[src/middleware/helpers/middleware-response-wrapper.ts:19](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L19)
 
 [fake-pev-shopping](#readmemd) / helpers/middleware-response-wrapper
 
@@ -918,7 +940,7 @@ Custom wrapper to secure consistent usage of a few [`Express#res`](https://expre
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:62](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L62)
+[src/middleware/helpers/middleware-response-wrapper.ts:62](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L62)
 
 ___
 
@@ -928,7 +950,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:65](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L65)
+[src/middleware/helpers/middleware-response-wrapper.ts:65](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L65)
 
 ___
 
@@ -938,7 +960,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:56](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L56)
+[src/middleware/helpers/middleware-response-wrapper.ts:56](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L56)
 
 ___
 
@@ -948,7 +970,7 @@ ___
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:39](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L39)
+[src/middleware/helpers/middleware-response-wrapper.ts:39](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L39)
 
 ## Functions
 
@@ -983,7 +1005,7 @@ wrapRes(res, HTTP_STATUS_CODE.NOT_FOUND, { error: 'Resource not found!' });
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:83](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L83)
+[src/middleware/helpers/middleware-response-wrapper.ts:83](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L83)
 
 ▸ **wrapRes**<`Payload`, `Status`, `DataKey`\>(`res`, `status`, `data`): `Response`
 
@@ -1023,7 +1045,7 @@ wrapRes(res, HTTP_STATUS_CODE.NOT_FOUND, { error: 'Resource not found!' });
 
 #### Defined in
 
-[src/middleware/helpers/middleware-response-wrapper.ts:87](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/helpers/middleware-response-wrapper.ts#L87)
+[src/middleware/helpers/middleware-response-wrapper.ts:87](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/helpers/middleware-response-wrapper.ts#L87)
 
 [fake-pev-shopping](#readmemd) / [routes/api-config](#modulesroutes_api_configmd) / <internal\>
 
@@ -1057,7 +1079,7 @@ wrapRes(res, HTTP_STATUS_CODE.NOT_FOUND, { error: 'Resource not found!' });
 
 #### Defined in
 
-[src/middleware/routes/api-config.ts:22](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-config.ts#L22)
+[src/middleware/routes/api-config.ts:22](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-config.ts#L22)
 
 [fake-pev-shopping](#readmemd) / routes/api-config
 
@@ -1081,7 +1103,7 @@ wrapRes(res, HTTP_STATUS_CODE.NOT_FOUND, { error: 'Resource not found!' });
 
 #### Defined in
 
-[src/middleware/routes/api-config.ts:14](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-config.ts#L14)
+[src/middleware/routes/api-config.ts:14](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-config.ts#L14)
 
 [fake-pev-shopping](#readmemd) / [routes/api-orders](#modulesroutes_api_ordersmd) / <internal\>
 
@@ -1115,7 +1137,7 @@ wrapRes(res, HTTP_STATUS_CODE.NOT_FOUND, { error: 'Resource not found!' });
 
 #### Defined in
 
-[src/middleware/routes/api-orders.ts:37](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-orders.ts#L37)
+[src/middleware/routes/api-orders.ts:37](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-orders.ts#L37)
 
 ___
 
@@ -1137,7 +1159,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-orders.ts:46](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-orders.ts#L46)
+[src/middleware/routes/api-orders.ts:46](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-orders.ts#L46)
 
 [fake-pev-shopping](#readmemd) / routes/api-orders
 
@@ -1161,7 +1183,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-orders.ts:14](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-orders.ts#L14)
+[src/middleware/routes/api-orders.ts:14](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-orders.ts#L14)
 
 [fake-pev-shopping](#readmemd) / routes/api-product-categories
 
@@ -1181,7 +1203,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-product-categories.ts:14](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-product-categories.ts#L14)
+[src/middleware/routes/api-product-categories.ts:14](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-product-categories.ts#L14)
 
 [fake-pev-shopping](#readmemd) / [routes/api-products](#modulesroutes_api_productsmd) / [<internal\>](#modulesroutes_api_products_internal_md) / addReview
 
@@ -1214,7 +1236,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-products.ts:277](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-products.ts#L277)
+[src/middleware/routes/api-products.ts:277](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-products.ts#L277)
 
 ___
 
@@ -1234,7 +1256,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-products.ts:276](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-products.ts#L276)
+[src/middleware/routes/api-products.ts:276](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-products.ts#L276)
 
 [fake-pev-shopping](#readmemd) / [routes/api-products](#modulesroutes_api_productsmd) / <internal\>
 
@@ -1277,7 +1299,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-products.ts:164](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-products.ts#L164)
+[src/middleware/routes/api-products.ts:164](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-products.ts#L164)
 
 ___
 
@@ -1299,7 +1321,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-products.ts:220](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-products.ts#L220)
+[src/middleware/routes/api-products.ts:220](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-products.ts#L220)
 
 ___
 
@@ -1321,7 +1343,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-products.ts:311](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-products.ts#L311)
+[src/middleware/routes/api-products.ts:311](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-products.ts#L311)
 
 ___
 
@@ -1343,7 +1365,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-products.ts:144](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-products.ts#L144)
+[src/middleware/routes/api-products.ts:144](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-products.ts#L144)
 
 ___
 
@@ -1365,7 +1387,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-products.ts:81](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-products.ts#L81)
+[src/middleware/routes/api-products.ts:81](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-products.ts#L81)
 
 ___
 
@@ -1387,7 +1409,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-products.ts:284](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-products.ts#L284)
+[src/middleware/routes/api-products.ts:284](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-products.ts#L284)
 
 [fake-pev-shopping](#readmemd) / routes/api-products
 
@@ -1411,7 +1433,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-products.ts:19](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-products.ts#L19)
+[src/middleware/routes/api-products.ts:19](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-products.ts#L19)
 
 [fake-pev-shopping](#readmemd) / [routes/api-user-roles](#modulesroutes_api_user_rolesmd) / <internal\>
 
@@ -1449,7 +1471,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-user-roles.ts:13](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-user-roles.ts#L13)
+[src/middleware/routes/api-user-roles.ts:13](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-user-roles.ts#L13)
 
 [fake-pev-shopping](#readmemd) / routes/api-user-roles
 
@@ -1473,7 +1495,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-user-roles.ts:16](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-user-roles.ts#L16)
+[src/middleware/routes/api-user-roles.ts:16](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-user-roles.ts#L16)
 
 [fake-pev-shopping](#readmemd) / [routes/api-users](#modulesroutes_api_usersmd) / <internal\>
 
@@ -1522,7 +1544,7 @@ ___
 
 #### Defined in
 
-[src/database/models/_user.ts:306](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/database/models/_user.ts#L306)
+[src/database/models/_user.ts:306](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/database/models/_user.ts#L306)
 
 ## Functions
 
@@ -1544,7 +1566,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-users.ts:519](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-users.ts#L519)
+[src/middleware/routes/api-users.ts:519](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-users.ts#L519)
 
 ___
 
@@ -1566,7 +1588,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-users.ts:368](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-users.ts#L368)
+[src/middleware/routes/api-users.ts:368](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-users.ts#L368)
 
 ___
 
@@ -1588,7 +1610,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-users.ts:266](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-users.ts#L266)
+[src/middleware/routes/api-users.ts:266](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-users.ts#L266)
 
 ___
 
@@ -1610,7 +1632,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-users.ts:610](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-users.ts#L610)
+[src/middleware/routes/api-users.ts:610](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-users.ts#L610)
 
 ___
 
@@ -1632,7 +1654,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-users.ts:583](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-users.ts#L583)
+[src/middleware/routes/api-users.ts:583](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-users.ts#L583)
 
 ___
 
@@ -1654,7 +1676,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-users.ts:493](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-users.ts#L493)
+[src/middleware/routes/api-users.ts:493](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-users.ts#L493)
 
 ___
 
@@ -1676,7 +1698,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-users.ts:325](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-users.ts#L325)
+[src/middleware/routes/api-users.ts:325](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-users.ts#L325)
 
 ___
 
@@ -1698,7 +1720,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-users.ts:455](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-users.ts#L455)
+[src/middleware/routes/api-users.ts:455](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-users.ts#L455)
 
 ___
 
@@ -1720,7 +1742,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-users.ts:471](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-users.ts#L471)
+[src/middleware/routes/api-users.ts:471](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-users.ts#L471)
 
 ___
 
@@ -1742,7 +1764,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-users.ts:233](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-users.ts#L233)
+[src/middleware/routes/api-users.ts:233](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-users.ts#L233)
 
 ___
 
@@ -1764,7 +1786,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-users.ts:567](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-users.ts#L567)
+[src/middleware/routes/api-users.ts:567](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-users.ts#L567)
 
 ___
 
@@ -1786,7 +1808,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-users.ts:543](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-users.ts#L543)
+[src/middleware/routes/api-users.ts:543](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-users.ts#L543)
 
 ___
 
@@ -1808,7 +1830,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-users.ts:293](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-users.ts#L293)
+[src/middleware/routes/api-users.ts:293](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-users.ts#L293)
 
 ___
 
@@ -1830,7 +1852,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-users.ts:423](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-users.ts#L423)
+[src/middleware/routes/api-users.ts:423](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-users.ts#L423)
 
 ___
 
@@ -1852,7 +1874,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-users.ts:391](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-users.ts#L391)
+[src/middleware/routes/api-users.ts:391](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-users.ts#L391)
 
 ___
 
@@ -1874,7 +1896,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-users.ts:191](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-users.ts#L191)
+[src/middleware/routes/api-users.ts:191](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-users.ts#L191)
 
 ___
 
@@ -1896,7 +1918,7 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-users.ts:159](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-users.ts#L159)
+[src/middleware/routes/api-users.ts:159](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-users.ts#L159)
 
 [fake-pev-shopping](#readmemd) / routes/api-users
 
@@ -1920,4 +1942,4 @@ ___
 
 #### Defined in
 
-[src/middleware/routes/api-users.ts:17](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/16f94f9/src/middleware/routes/api-users.ts#L17)
+[src/middleware/routes/api-users.ts:17](https://github.com/ScriptyChris/Fake-PEV-Shopping/blob/2e7492c/src/middleware/routes/api-users.ts#L17)

--- a/commons/validators.ts
+++ b/commons/validators.ts
@@ -8,7 +8,7 @@ const VALIDATOR_SCHEMAS = {
     return { regExps, PRICE_MODIFIERS };
   })(),
   PRODUCT_SORTING: (() => {
-    const SORTING_MODIFIERS = ['name', 'price'] as const;
+    const SORTING_MODIFIERS = ['name', 'price', 'reviews.ratingScore'] as const;
     const SORTING_ORDER_MAP = {
       Asc: 'Asc',
       Desc: 'Desc',

--- a/commons/validators.ts
+++ b/commons/validators.ts
@@ -8,7 +8,7 @@ const VALIDATOR_SCHEMAS = {
     return { regExps, PRICE_MODIFIERS };
   })(),
   PRODUCT_SORTING: (() => {
-    const SORTING_MODIFIERS = ['name', 'price', 'reviews.ratingScore', 'orderedUnits'] as const;
+    const SORTING_MODIFIERS = ['name', 'price', 'reviews.ratingScore', 'orderedUnits', 'createdAt'] as const;
     const SORTING_ORDER_MAP = {
       Asc: 'Asc',
       Desc: 'Desc',

--- a/commons/validators.ts
+++ b/commons/validators.ts
@@ -8,7 +8,7 @@ const VALIDATOR_SCHEMAS = {
     return { regExps, PRICE_MODIFIERS };
   })(),
   PRODUCT_SORTING: (() => {
-    const SORTING_MODIFIERS = ['name', 'price', 'reviews.ratingScore'] as const;
+    const SORTING_MODIFIERS = ['name', 'price', 'reviews.ratingScore', 'orderedUnits'] as const;
     const SORTING_ORDER_MAP = {
       Asc: 'Asc',
       Desc: 'Desc',

--- a/src/database/models/_order.ts
+++ b/src/database/models/_order.ts
@@ -40,6 +40,7 @@ orderedProductSchema.virtual('productRef', {
 });
 orderedProductSchema.post('save', async (doc: IProductInOrder & Document) => {
   doc.$locals.productRef.availability -= doc.quantity;
+  doc.$locals.productRef.orderedUnits += doc.quantity;
   await doc.$locals.productRef.save();
 });
 
@@ -165,6 +166,10 @@ orderSchema.statics.createOrder = (
 };
 
 export const OrderModel = model<IOrder, IOrderModel>(COLLECTION_NAMES.Order, orderSchema);
+export type TOrderToPopulate = IOrder & {
+  __regardingUser: string;
+  regardingProducts: (IOrder['regardingProducts'][number] & { __name: string })[];
+};
 
 interface IOrderModel extends Model<IOrder> {
   createOrder(

--- a/src/database/models/_product.ts
+++ b/src/database/models/_product.ts
@@ -236,6 +236,13 @@ const productSchema = new Schema<IProduct>({
       return value >= MIN_PRODUCT_UNITS && value <= MAX_PRODUCT_UNITS;
     },
   },
+  orderedUnits: {
+    type: Number,
+    default: 0,
+    validate(value: number) {
+      return value >= 0;
+    },
+  },
 });
 productSchema.pre('validate', function (next: () => void) {
   const product = this as IProduct;
@@ -486,6 +493,7 @@ export interface IProduct extends Document {
   relatedProductsNames: string[];
   reviews: IReviews;
   availability: number;
+  orderedUnits: number;
 
   prepareUrlField(): void;
   transformImagesToImagePaths(): void;

--- a/src/database/models/_product.ts
+++ b/src/database/models/_product.ts
@@ -243,6 +243,11 @@ const productSchema = new Schema<IProduct>({
       return value >= 0;
     },
   },
+  createdAt: {
+    type: Number,
+    default: Date.now(),
+    immutable: true,
+  },
 });
 productSchema.pre('validate', function (next: () => void) {
   const product = this as IProduct;
@@ -494,6 +499,7 @@ export interface IProduct extends Document {
   reviews: IReviews;
   availability: number;
   orderedUnits: number;
+  createdAt: number;
 
   prepareUrlField(): void;
   transformImagesToImagePaths(): void;

--- a/src/database/populate/initialData/orders.json
+++ b/src/database/populate/initialData/orders.json
@@ -1,0 +1,48 @@
+[
+  {
+    "receiver": {
+      "name": "Test client's name",
+      "email": "test_client@example.org",
+      "phone": "123456789"
+    },
+    "payment": {
+      "method": "cash"
+    },
+    "shipment": {
+      "method": "inPerson",
+      "address": "PEV Shop,ul. Testable 1,12-345 Testland"
+    },
+    "__regardingUser": "test client",
+    "regardingProducts": [
+      {
+        "quantity": 2,
+        "__name": "GW ACMs+/MSuper V3s+: 800Wh, 84.2v Battery Pack"
+      }
+    ]
+  },
+  {
+    "receiver": {
+      "name": "Test client's name",
+      "email": "test_client@example.org",
+      "phone": "123456789"
+    },
+    "payment": {
+      "method": "card"
+    },
+    "shipment": {
+      "method": "inPerson",
+      "address": "PEV Shop,ul. Testable 1,12-345 Testland"
+    },
+    "__regardingUser": "test client",
+    "regardingProducts": [
+      {
+        "quantity": 1,
+        "__name": "Dualtron 2- Handlebar Support Strut & Suspension"
+      },
+      {
+        "quantity": 3,
+        "__name": "King Song 14D, 340/420Wh Battery, 800W Motor"
+      }
+    ]
+  }
+]

--- a/src/frontend/assets/styles/views/home.scss
+++ b/src/frontend/assets/styles/views/home.scss
@@ -4,16 +4,18 @@
 
 .home-section {
     &__product-list {
+        --product-card-width: 200px;
+        --scrollable-min-height: 8rem;
         display: flex;
         align-items: center;
-        --product-card-width: 200px;
+        min-height: var(--scrollable-min-height);
 
         [data-compare-btn-scroll-dir] button {
             width: 2rem;
         }
 
         [data-scrollable-parent] {
-            --scrollable-min-height: 8rem;
+            --scrollable-min-height: inherit;
         }
 
         ul {

--- a/src/frontend/assets/styles/views/pevElements.scss
+++ b/src/frontend/assets/styles/views/pevElements.scss
@@ -49,4 +49,9 @@
         background: $blueColor;
         color: $whiteColor;
     }
+
+    &-text-field-wrapper input[readonly] {
+        background: $greyColor;
+        color: $veryDarkGreyColor;
+    }
 }

--- a/src/frontend/components/utils/pevElements.jsx
+++ b/src/frontend/components/utils/pevElements.jsx
@@ -42,7 +42,15 @@ const FormikTextFieldForwarder = ({ field: _field, form, defaultValue, ...props 
     [defaultValue === null || defaultValue === undefined ? 'value' : 'defaultValue']: defaultValue ?? value,
   };
 
-  return <TextField {...restProps} {...field} {...overrideProps} {...valueOrDefaultValue} />;
+  return (
+    <TextField
+      className="pev-element-text-field-wrapper"
+      {...restProps}
+      {...field}
+      {...overrideProps}
+      {...valueOrDefaultValue}
+    />
+  );
 };
 
 export const PEVButton = forwardRef(function PEVButton({ children, ...props }, ref) {

--- a/src/frontend/components/views/productsDashboard.jsx
+++ b/src/frontend/components/views/productsDashboard.jsx
@@ -11,6 +11,7 @@ import SortByAlphaIcon from '@material-ui/icons/SortByAlpha';
 import AttachMoneyIcon from '@material-ui/icons/AttachMoney';
 import StarRateIcon from '@material-ui/icons/StarRate';
 import ShopIcon from '@material-ui/icons/Shop';
+import CalendarTodayIcon from '@material-ui/icons/CalendarToday';
 import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward';
 import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
 import ViewModuleIcon from '@material-ui/icons/ViewModule';
@@ -54,6 +55,7 @@ const translations = {
   sortByPriceDesc: 'Price descending',
   sortByRatingScoreDesc: 'Rating descending',
   sortByOrderedUnitsDesc: 'Sold descending',
+  sortByCreatedAtDesc: 'Newest descending',
   tabletFiltersToggleBtn: 'toggle filters',
   filtersHeading: 'Filters',
   priceFilterHeading: 'Price',
@@ -620,6 +622,16 @@ function Sorting({ sortBy = '', updateProductsDashboardQuery }) {
       icons: (
         <>
           <ShopIcon {...iconCommonProps} />
+          <ArrowDownwardIcon {...iconCommonProps} />
+        </>
+      ),
+    },
+    {
+      value: 'createdAtDesc',
+      translation: translations.sortByCreatedAtDesc,
+      icons: (
+        <>
+          <CalendarTodayIcon {...iconCommonProps} />
           <ArrowDownwardIcon {...iconCommonProps} />
         </>
       ),

--- a/src/frontend/components/views/productsDashboard.jsx
+++ b/src/frontend/components/views/productsDashboard.jsx
@@ -9,6 +9,7 @@ import TuneIcon from '@material-ui/icons/Tune';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import SortByAlphaIcon from '@material-ui/icons/SortByAlpha';
 import AttachMoneyIcon from '@material-ui/icons/AttachMoney';
+import StarRateIcon from '@material-ui/icons/StarRate';
 import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward';
 import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
 import ViewModuleIcon from '@material-ui/icons/ViewModule';
@@ -50,6 +51,7 @@ const translations = {
   sortByNameDesc: 'Name descending',
   sortByPriceAsc: 'Price ascending',
   sortByPriceDesc: 'Price descending',
+  sortByRatingScoreDesc: 'Rating descending',
   tabletFiltersToggleBtn: 'toggle filters',
   filtersHeading: 'Filters',
   priceFilterHeading: 'Price',
@@ -601,26 +603,6 @@ function Sorting({ sortBy = '', updateProductsDashboardQuery }) {
   };
   const sortOptions = [
     {
-      value: 'nameAsc',
-      translation: translations.sortByNameAsc,
-      icons: (
-        <>
-          <SortByAlphaIcon className="products-dashboard__sorting-alpha-icon" {...iconCommonProps} />
-          <ArrowUpwardIcon {...iconCommonProps} />
-        </>
-      ),
-    },
-    {
-      value: 'nameDesc',
-      translation: translations.sortByNameDesc,
-      icons: (
-        <>
-          <SortByAlphaIcon className="products-dashboard__sorting-alpha-icon" {...iconCommonProps} />
-          <ArrowDownwardIcon {...iconCommonProps} />
-        </>
-      ),
-    },
-    {
       value: 'priceAsc',
       translation: translations.sortByPriceAsc,
       icons: (
@@ -636,6 +618,36 @@ function Sorting({ sortBy = '', updateProductsDashboardQuery }) {
       icons: (
         <>
           <AttachMoneyIcon {...iconCommonProps} />
+          <ArrowDownwardIcon {...iconCommonProps} />
+        </>
+      ),
+    },
+    {
+      value: 'reviews.ratingScoreDesc',
+      translation: translations.sortByRatingScoreDesc,
+      icons: (
+        <>
+          <StarRateIcon {...iconCommonProps} />
+          <ArrowDownwardIcon {...iconCommonProps} />
+        </>
+      ),
+    },
+    {
+      value: 'nameAsc',
+      translation: translations.sortByNameAsc,
+      icons: (
+        <>
+          <SortByAlphaIcon className="products-dashboard__sorting-alpha-icon" {...iconCommonProps} />
+          <ArrowUpwardIcon {...iconCommonProps} />
+        </>
+      ),
+    },
+    {
+      value: 'nameDesc',
+      translation: translations.sortByNameDesc,
+      icons: (
+        <>
+          <SortByAlphaIcon className="products-dashboard__sorting-alpha-icon" {...iconCommonProps} />
           <ArrowDownwardIcon {...iconCommonProps} />
         </>
       ),

--- a/src/frontend/components/views/productsDashboard.jsx
+++ b/src/frontend/components/views/productsDashboard.jsx
@@ -10,6 +10,7 @@ import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import SortByAlphaIcon from '@material-ui/icons/SortByAlpha';
 import AttachMoneyIcon from '@material-ui/icons/AttachMoney';
 import StarRateIcon from '@material-ui/icons/StarRate';
+import ShopIcon from '@material-ui/icons/Shop';
 import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward';
 import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
 import ViewModuleIcon from '@material-ui/icons/ViewModule';
@@ -52,6 +53,7 @@ const translations = {
   sortByPriceAsc: 'Price ascending',
   sortByPriceDesc: 'Price descending',
   sortByRatingScoreDesc: 'Rating descending',
+  sortByOrderedUnitsDesc: 'Sold descending',
   tabletFiltersToggleBtn: 'toggle filters',
   filtersHeading: 'Filters',
   priceFilterHeading: 'Price',
@@ -603,6 +605,26 @@ function Sorting({ sortBy = '', updateProductsDashboardQuery }) {
   };
   const sortOptions = [
     {
+      value: 'reviews.ratingScoreDesc',
+      translation: translations.sortByRatingScoreDesc,
+      icons: (
+        <>
+          <StarRateIcon {...iconCommonProps} />
+          <ArrowDownwardIcon {...iconCommonProps} />
+        </>
+      ),
+    },
+    {
+      value: 'orderedUnitsDesc',
+      translation: translations.sortByOrderedUnitsDesc,
+      icons: (
+        <>
+          <ShopIcon {...iconCommonProps} />
+          <ArrowDownwardIcon {...iconCommonProps} />
+        </>
+      ),
+    },
+    {
       value: 'priceAsc',
       translation: translations.sortByPriceAsc,
       icons: (
@@ -618,16 +640,6 @@ function Sorting({ sortBy = '', updateProductsDashboardQuery }) {
       icons: (
         <>
           <AttachMoneyIcon {...iconCommonProps} />
-          <ArrowDownwardIcon {...iconCommonProps} />
-        </>
-      ),
-    },
-    {
-      value: 'reviews.ratingScoreDesc',
-      translation: translations.sortByRatingScoreDesc,
-      icons: (
-        <>
-          <StarRateIcon {...iconCommonProps} />
           <ArrowDownwardIcon {...iconCommonProps} />
         </>
       ),

--- a/src/frontend/features/httpService.ts
+++ b/src/frontend/features/httpService.ts
@@ -400,7 +400,7 @@ class HttpService extends Ajax {
         data: productModifications,
       },
     };
-    return this.patchRequest(this.URLS.PRODUCTS, modifiedProductData);
+    return this.patchRequest(this.URLS.PRODUCTS, modifiedProductData, true);
   }
 
   /**

--- a/src/middleware/middleware-index.ts
+++ b/src/middleware/middleware-index.ts
@@ -127,7 +127,13 @@ function imageHandler() {
   return [
     `/${IMAGES_ROOT_PATH}/*`,
     (req: Request, res: Response) => {
-      const imagePath = globalThis.decodeURIComponent(possiblyReEncodeURI(req.url.split('/').slice(3).join('/')));
+      const imagePossibleUrl = req.url
+        .split('/')
+        .slice(3)
+        .join('/')
+        // remove any dangling query params (like cache invalidation)
+        .replace(/\?.*/, '');
+      const imagePath = globalThis.decodeURIComponent(possiblyReEncodeURI(imagePossibleUrl));
 
       getImage(imagePath)
         .then((image) => res.sendFile(image))

--- a/src/middleware/routes/api-products.ts
+++ b/src/middleware/routes/api-products.ts
@@ -210,7 +210,7 @@ async function addProduct(req: Request, res: Response, next: NextFunction) {
     const { url } = (await saveToDB(COLLECTION_NAMES.Product, newProductData)) as IProduct;
     moveValidImagesToTargetLocation(url, true);
 
-    return wrapRes(res, HTTP_STATUS_CODE.CREATED, { message: 'Success!' });
+    return wrapRes(res, HTTP_STATUS_CODE.CREATED, { payload: { productUrl: url } });
   } catch (exception) {
     removeTmpImages();
     return next(exception);

--- a/test/e2e/cypress/integration/product-form.spec.ts
+++ b/test/e2e/cypress/integration/product-form.spec.ts
@@ -180,12 +180,12 @@ describe('product-form', () => {
 
       // modify product
       cy.intercept('/api/products', (req) => {
-        req.headers.Authorization = `Bearer ${authToken}`;
         req.continue((res) => {
           expect(res.statusCode).to.eq(HTTP_STATUS_CODE.OK);
         });
       });
       cy.get(makeCyDataSelector('button:product-form__save')).click();
+      cy.contains(makeCyDataSelector('popup:message'), 'Product modified!');
 
       // assert update succeeded
       assertProductDataInsideForm(updatedProductFormData.assertable);
@@ -267,7 +267,6 @@ describe('product-form', () => {
 
       // save new product
       cy.intercept('/api/products', (req) => {
-        req.headers.Authorization = `Bearer ${authToken}`;
         req.continue((res) => {
           expect(res.body).to.include({
             message: 'Success!',
@@ -275,6 +274,7 @@ describe('product-form', () => {
         });
       });
       cy.get(makeCyDataSelector('button:product-form__save')).click();
+      cy.contains(makeCyDataSelector('popup:message'), 'Product added!');
 
       // assert new product has been saved by checking it's modification form
       assertProductDataInsideForm(testProductDataForForm);

--- a/test/unit/middleware/routes/api-products.spec.ts
+++ b/test/unit/middleware/routes/api-products.spec.ts
@@ -286,11 +286,18 @@ describe('#api-products', () => {
 
       it('should call res.status(..).json(..) with correct params', async () => {
         const resMock = getResMock();
+        const newProductUrlMock = 'new-product-url';
+        saveToDBMock.mockReset().mockImplementationOnce(async () => {
+          const mockResult = await saveToDBMock._succeededCall();
+          mockResult.url = newProductUrlMock;
+
+          return mockResult;
+        });
 
         await apiProductsRouter._addProduct(getReqMock(), resMock);
 
         expect(resMock.status).toHaveBeenCalledWith(HTTP_STATUS_CODE.CREATED);
-        expect(resMock._jsonMethod).toHaveBeenCalledWith({ message: 'Success!' });
+        expect(resMock._jsonMethod).toHaveBeenCalledWith({ payload: { productUrl: newProductUrlMock } });
       });
     });
 


### PR DESCRIPTION
- extended `ProductsDashboard` sorting with:
  - rating score, 
  - sold units, 
  - creation date
- improved `ProductForm` UX by showing a popup on successful save with possibility to redirect user to (newly created or just updated) product's page
- completed `Home` page sections according to extended products sorting